### PR TITLE
manifests: add cluster reconciler RBAC and SA

### DIFF
--- a/manifests/bases/kustomize-controller/cluster_role.yaml
+++ b/manifests/bases/kustomize-controller/cluster_role.yaml
@@ -1,13 +1,8 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cluster-reconciler
-rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ['*']
-  - nonResourceURLs: ['*']
-    verbs: ['*']
+  namespace: system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16,8 +11,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-reconciler
+  name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: cluster-reconciler
     namespace: system

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/fluxcd/kustomize-controller/config//crd?ref=v0.0.1-alpha.5
-- github.com/fluxcd/kustomize-controller/config//manager?ref=v0.0.1-alpha.5
+- github.com/fluxcd/kustomize-controller/config//crd?ref=v0.0.1-alpha.6
+- github.com/fluxcd/kustomize-controller/config//manager?ref=v0.0.1-alpha.6
+- cluster_role.yaml
+patchesStrategicMerge:
+- patch.yaml

--- a/manifests/bases/kustomize-controller/patch.yaml
+++ b/manifests/bases/kustomize-controller/patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize-controller
+spec:
+  template:
+    spec:
+      serviceAccountName: cluster-reconciler

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster_role.yaml
   - role.yaml


### PR DESCRIPTION
Changes:
- add cluster reconciler RBAC and SA for kustomize controller
- bump kustomize controller version to v0.0.1-alpha.6