### PR TITLE
manifests: fix leader election rbac

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
           ./bin/tk uninstall --namespace=test --crds --silent
       - name: tk install --manifests
         run: |
-          ./bin/tk install --manifests ./manifests/install/
+          ./bin/tk install --manifests ./manifests/install/ --version=""
       - name: tk create source git
         run: |
           ./bin/tk create source git podinfo \
@@ -99,3 +99,5 @@ jobs:
           kubectl version --client --short
           kustomize version --short
           kubectl -n gitops-system get all
+          kubectl -n gitops-system logs deploy/source-controller
+          kubectl -n gitops-system logs deploy/kustomize-controller

--- a/manifests/bases/kustomize-controller/kustomization.yaml
+++ b/manifests/bases/kustomize-controller/kustomization.yaml
@@ -3,6 +3,3 @@ kind: Kustomization
 resources:
 - github.com/fluxcd/kustomize-controller/config//crd?ref=v0.0.1-alpha.6
 - github.com/fluxcd/kustomize-controller/config//manager?ref=v0.0.1-alpha.6
-- cluster_role.yaml
-patchesStrategicMerge:
-- patch.yaml

--- a/manifests/bases/kustomize-controller/patch.yaml
+++ b/manifests/bases/kustomize-controller/patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kustomize-controller
-spec:
-  template:
-    spec:
-      serviceAccountName: cluster-reconciler

--- a/manifests/rbac/cluster-role.yaml
+++ b/manifests/rbac/cluster-role.yaml
@@ -1,9 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cluster-reconciler
-  namespace: system
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,5 +8,5 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: cluster-reconciler
+    name: default
     namespace: system

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - role.yaml
+  - cluster-role.yaml

--- a/manifests/rbac/role.yaml
+++ b/manifests/rbac/role.yaml
@@ -9,6 +9,18 @@ rules:
 - apiGroups: ['kustomize.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/status
+  verbs: ['*']
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
We should set the controllers to watch only the runtime namespace for CRs. Until then, the cluster role binding is required on both controllers.