### PR TITLE
Fix deny traffic from other namespaces

### DIFF
--- a/manifests/policies/deny-ingress.yaml
+++ b/manifests/policies/deny-ingress.yaml
@@ -6,3 +6,6 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
+  ingress:
+  - from:
+    - podSelector: {}


### PR DESCRIPTION
Allow intra-namespace traffic, e.g. kustomize-controller -> source-controller.