### PR TITLE
Use semver manifests as kustomize base

### DIFF
--- a/cmd/tk/bootstrap.go
+++ b/cmd/tk/bootstrap.go
@@ -58,7 +58,7 @@ const (
 
 func init() {
 	bootstrapCmd.PersistentFlags().StringVarP(&bootstrapVersion, "version", "v", defaultVersion,
-		"toolkit tag or branch")
+		"toolkit version")
 	bootstrapCmd.PersistentFlags().StringSliceVar(&bootstrapComponents, "components", defaultComponents,
 		"list of components, accepts comma-separated values")
 

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -105,7 +105,7 @@ var (
 
 var (
 	defaultComponents = []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}
-	defaultVersion    = "master"
+	defaultVersion    = "latest"
 	defaultNamespace  = "gitops-system"
 )
 

--- a/cmd/tk/utils.go
+++ b/cmd/tk/utils.go
@@ -143,3 +143,23 @@ func (*Utils) writeFile(content, filename string) error {
 
 	return file.Sync()
 }
+
+func (*Utils) copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/docs/cmd/tk_bootstrap.md
+++ b/docs/cmd/tk_bootstrap.md
@@ -11,7 +11,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ```
       --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                 help for bootstrap
-  -v, --version string       toolkit tag or branch (default "master")
+  -v, --version string       toolkit version (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tk_bootstrap_github.md
+++ b/docs/cmd/tk_bootstrap_github.md
@@ -59,7 +59,7 @@ tk bootstrap github [flags]
       --namespace string     the namespace scope for this operation (default "gitops-system")
       --timeout duration     timeout for this operation (default 5m0s)
       --verbose              print generated objects
-  -v, --version string       toolkit tag or branch (default "master")
+  -v, --version string       toolkit version (default "latest")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tk_bootstrap_gitlab.md
+++ b/docs/cmd/tk_bootstrap_gitlab.md
@@ -55,7 +55,7 @@ tk bootstrap gitlab [flags]
       --namespace string     the namespace scope for this operation (default "gitops-system")
       --timeout duration     timeout for this operation (default 5m0s)
       --verbose              print generated objects
-  -v, --version string       toolkit tag or branch (default "master")
+  -v, --version string       toolkit version (default "latest")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tk_install.md
+++ b/docs/cmd/tk_install.md
@@ -15,10 +15,10 @@ tk install [flags]
 
 ```
   # Install the latest version in the gitops-systems namespace
-  tk install --version=master --namespace=gitops-systems
+  tk install --version=latest --namespace=gitops-systems
 
   # Dry-run install for a specific version and a series of components
-  tk install --dry-run --version=0.0.1 --components="source-controller,kustomize-controller"
+  tk install --dry-run --version=v0.0.7 --components="source-controller,kustomize-controller"
 
   # Dry-run install with manifests preview 
   tk install --dry-run --verbose
@@ -36,7 +36,7 @@ tk install [flags]
       --export               write the install manifests to stdout and exit
   -h, --help                 help for install
       --manifests string     path to the manifest directory, dev only
-  -v, --version string       toolkit tag or branch (default "master")
+  -v, --version string       toolkit version (default "latest")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Instead of cloning the components repositories to download the base manifests, we [build them in CI at release time](https://github.com/fluxcd/toolkit/blob/master/.github/workflows/release.yaml) and download them in `tk install/bootstrap` based on the provided semver. This speeds up the manifests generation from minutes to milliseconds.