### PR TITLE
Make notification component optional

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -104,9 +104,10 @@ var (
 )
 
 var (
-	defaultComponents = []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}
-	defaultVersion    = "latest"
-	defaultNamespace  = "gitops-system"
+	defaultComponents   = []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}
+	defaultVersion      = "latest"
+	defaultNamespace    = "gitops-system"
+	defaultNotification = "notification-controller"
 )
 
 func init() {

--- a/cmd/tk/utils.go
+++ b/cmd/tk/utils.go
@@ -166,3 +166,12 @@ func (*Utils) copyFile(src, dst string) error {
 	}
 	return out.Close()
 }
+
+func (*Utils) containsItemString(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
If one chooses to install the toolkit components without notification-controller, the installed controllers should only create Kubernetes events. This PR adds a patch to the controllers args to remove the events address when notification-controller is not one of the selected components.