### PR TITLE
Add container registry and image pull secret as install options

### DIFF
--- a/cmd/tk/bootstrap.go
+++ b/cmd/tk/bootstrap.go
@@ -47,6 +47,7 @@ var bootstrapCmd = &cobra.Command{
 var (
 	bootstrapVersion    string
 	bootstrapComponents []string
+	bootstrapRegistry   string
 )
 
 const (
@@ -61,7 +62,8 @@ func init() {
 		"toolkit version")
 	bootstrapCmd.PersistentFlags().StringSliceVar(&bootstrapComponents, "components", defaultComponents,
 		"list of components, accepts comma-separated values")
-
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapRegistry, "registry", "docker.io/fluxcd",
+		"container registry where the toolkit images are published")
 	rootCmd.AddCommand(bootstrapCmd)
 }
 
@@ -73,7 +75,7 @@ func generateInstallManifests(targetPath, namespace, tmpDir string) (string, err
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 
-	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents, tkDir); err != nil {
+	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents, bootstrapRegistry, tkDir); err != nil {
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 

--- a/cmd/tk/bootstrap.go
+++ b/cmd/tk/bootstrap.go
@@ -45,9 +45,10 @@ var bootstrapCmd = &cobra.Command{
 }
 
 var (
-	bootstrapVersion    string
-	bootstrapComponents []string
-	bootstrapRegistry   string
+	bootstrapVersion         string
+	bootstrapComponents      []string
+	bootstrapRegistry        string
+	bootstrapImagePullSecret string
 )
 
 const (
@@ -64,6 +65,8 @@ func init() {
 		"list of components, accepts comma-separated values")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapRegistry, "registry", "docker.io/fluxcd",
 		"container registry where the toolkit images are published")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapImagePullSecret, "image-pull-secret", "",
+		"Kubernetes secret name used for pulling the toolkit images from a private registry")
 	rootCmd.AddCommand(bootstrapCmd)
 }
 
@@ -75,7 +78,7 @@ func generateInstallManifests(targetPath, namespace, tmpDir string) (string, err
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 
-	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents, bootstrapRegistry, tkDir); err != nil {
+	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents, bootstrapRegistry, bootstrapImagePullSecret, tkDir); err != nil {
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 

--- a/docs/cmd/tk_bootstrap.md
+++ b/docs/cmd/tk_bootstrap.md
@@ -9,10 +9,11 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ### Options
 
 ```
-      --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
-  -h, --help                 help for bootstrap
-      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
-  -v, --version string       toolkit version (default "latest")
+      --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+  -h, --help                       help for bootstrap
+      --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+  -v, --version string             toolkit version (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tk_bootstrap.md
+++ b/docs/cmd/tk_bootstrap.md
@@ -11,6 +11,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 ```
       --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                 help for bootstrap
+      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
   -v, --version string       toolkit version (default "latest")
 ```
 

--- a/docs/cmd/tk_bootstrap_github.md
+++ b/docs/cmd/tk_bootstrap_github.md
@@ -57,6 +57,7 @@ tk bootstrap github [flags]
       --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --kubeconfig string    path to the kubeconfig file (default "~/.kube/config")
       --namespace string     the namespace scope for this operation (default "gitops-system")
+      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
       --timeout duration     timeout for this operation (default 5m0s)
       --verbose              print generated objects
   -v, --version string       toolkit version (default "latest")

--- a/docs/cmd/tk_bootstrap_github.md
+++ b/docs/cmd/tk_bootstrap_github.md
@@ -54,13 +54,14 @@ tk bootstrap github [flags]
 ### Options inherited from parent commands
 
 ```
-      --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
-      --kubeconfig string    path to the kubeconfig file (default "~/.kube/config")
-      --namespace string     the namespace scope for this operation (default "gitops-system")
-      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
-      --timeout duration     timeout for this operation (default 5m0s)
-      --verbose              print generated objects
-  -v, --version string       toolkit version (default "latest")
+      --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
+      --namespace string           the namespace scope for this operation (default "gitops-system")
+      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --timeout duration           timeout for this operation (default 5m0s)
+      --verbose                    print generated objects
+  -v, --version string             toolkit version (default "latest")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tk_bootstrap_gitlab.md
+++ b/docs/cmd/tk_bootstrap_gitlab.md
@@ -50,13 +50,14 @@ tk bootstrap gitlab [flags]
 ### Options inherited from parent commands
 
 ```
-      --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
-      --kubeconfig string    path to the kubeconfig file (default "~/.kube/config")
-      --namespace string     the namespace scope for this operation (default "gitops-system")
-      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
-      --timeout duration     timeout for this operation (default 5m0s)
-      --verbose              print generated objects
-  -v, --version string       toolkit version (default "latest")
+      --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
+      --namespace string           the namespace scope for this operation (default "gitops-system")
+      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --timeout duration           timeout for this operation (default 5m0s)
+      --verbose                    print generated objects
+  -v, --version string             toolkit version (default "latest")
 ```
 
 ### SEE ALSO

--- a/docs/cmd/tk_bootstrap_gitlab.md
+++ b/docs/cmd/tk_bootstrap_gitlab.md
@@ -53,6 +53,7 @@ tk bootstrap gitlab [flags]
       --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --kubeconfig string    path to the kubeconfig file (default "~/.kube/config")
       --namespace string     the namespace scope for this operation (default "gitops-system")
+      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
       --timeout duration     timeout for this operation (default 5m0s)
       --verbose              print generated objects
   -v, --version string       toolkit version (default "latest")

--- a/docs/cmd/tk_install.md
+++ b/docs/cmd/tk_install.md
@@ -31,13 +31,14 @@ tk install [flags]
 ### Options
 
 ```
-      --components strings   list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
-      --dry-run              only print the object that would be applied
-      --export               write the install manifests to stdout and exit
-  -h, --help                 help for install
-      --manifests string     path to the manifest directory, dev only
-      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
-  -v, --version string       toolkit version (default "latest")
+      --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
+      --dry-run                    only print the object that would be applied
+      --export                     write the install manifests to stdout and exit
+  -h, --help                       help for install
+      --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --manifests string           path to the manifest directory, dev only
+      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+  -v, --version string             toolkit version (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/tk_install.md
+++ b/docs/cmd/tk_install.md
@@ -36,6 +36,7 @@ tk install [flags]
       --export               write the install manifests to stdout and exit
   -h, --help                 help for install
       --manifests string     path to the manifest directory, dev only
+      --registry string      container registry where the toolkit images are published (default "docker.io/fluxcd")
   -v, --version string       toolkit version (default "latest")
 ```
 


### PR DESCRIPTION
Changes to install and bootstrap commands:
- Add container registry optional arg 
- Add image pull secret optional arg

Example of installing the toolkit using images from a private repository:

```sh
tk install \
--namespace=gitops-system \
--components=source-controller,kustomize-controller \
--registry=registry.internal/fluxcd \
--image-pull-secret=regcred

kubectl -n gitops-system create secret generic regcred \
    --from-file=.dockerconfigjson=/.docker/config.json \
    --type=kubernetes.io/dockerconfigjson
```
