### PR TITLE
Use GitHub Container Registry for AMD64/ARM64 images

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -64,7 +64,7 @@ func init() {
 		"toolkit version")
 	bootstrapCmd.PersistentFlags().StringSliceVar(&bootstrapComponents, "components", defaultComponents,
 		"list of components, accepts comma-separated values")
-	bootstrapCmd.PersistentFlags().StringVar(&bootstrapRegistry, "registry", "docker.io/fluxcd",
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapRegistry, "registry", "ghcr.io/fluxcd",
 		"container registry where the toolkit images are published")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapImagePullSecret, "image-pull-secret", "",
 		"Kubernetes secret name used for pulling the toolkit images from a private registry")

--- a/cmd/gotk/install.go
+++ b/cmd/gotk/install.go
@@ -76,7 +76,7 @@ func init() {
 		"list of components, accepts comma-separated values")
 	installCmd.Flags().StringVar(&installManifestsPath, "manifests", "",
 		"path to the manifest directory, dev only")
-	installCmd.Flags().StringVar(&installRegistry, "registry", "docker.io/fluxcd",
+	installCmd.Flags().StringVar(&installRegistry, "registry", "ghcr.io/fluxcd",
 		"container registry where the toolkit images are published")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "",
 		"Kubernetes secret name used for pulling the toolkit images from a private registry")

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -13,7 +13,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
-      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
 ```
 

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -59,7 +59,7 @@ gotk bootstrap github [flags]
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --namespace string           the namespace scope for this operation (default "gitops-system")
-      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -56,7 +56,7 @@ gotk bootstrap gitlab [flags]
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --namespace string           the namespace scope for this operation (default "gitops-system")
-      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -38,7 +38,7 @@ gotk install [flags]
   -h, --help                       help for install
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --manifests string           path to the manifest directory, dev only
-      --registry string            container registry where the toolkit images are published (default "docker.io/fluxcd")
+      --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
 ```
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -178,12 +178,12 @@ gotk install --version=latest \
 ```
 
 If your cluster must pull images from a private container registry, first you should pull
-the toolkit images from Docker Hub and push them to your registry, for example:
+the toolkit images from GitHub Container Registry and push them to your registry, for example:
 
 ```sh
-docker pull fluxcd/source-controller:v0.0.7
-docker tag fluxcd/source-controller:v0.0.7 registry.internal/fluxcd/source-controller:v0.0.7
-docker push registry.internal/fluxcd/source-controller:v0.0.7
+docker pull ghcr.io/fluxcd/source-controller:v0.0.14
+docker tag ghcr.io/fluxcd/source-controller:v0.0.14 registry.internal/fluxcd/source-controller:v0.0.14
+docker push registry.internal/fluxcd/source-controller:v0.0.14
 ```
 
 Create the pull secret in the `gitops-system` namespace:


### PR DESCRIPTION
Use GitHub Container Registry instead of Docker Hub for the toolkit controller images linux/amd64 and arm64.

Fix: #194 