### PR TITLE
Add initial Homebrew formula

### DIFF
--- a/Formula/gotk.rb
+++ b/Formula/gotk.rb
@@ -1,0 +1,49 @@
+class Gotk < Formula
+  desc "Experimental toolkit for assembling CD pipelines the GitOps way"
+  homepage "https://toolkit.fluxcd.io/"
+  url "https://github.com/fluxcd/toolkit.git",
+      tag: "0.0.24",
+      revision: "d6c6c88e6e08d0ab7fa89c69241f1b1ca5aa658b"
+  head "https://github.com/fluxcd/toolkit.git"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+  depends_on "kubernetes-cli"
+
+  bottle :unneeded
+
+  def install
+    if build.stable?
+      bin.install "gotk"
+    else
+      ENV["CGO_ENABLED"] = "0"
+      cd buildpath/"cmd/gotk" do
+        system "go", "build", "-ldflags", "-s -w -X main.VERSION=#{version}", "-trimpath", "-o", bin/"gotk"
+      end
+    end
+  end
+
+  on_linux do
+    stable do
+      url "https://github.com/fluxcd/toolkit/releases/download/v0.0.24/gotk_0.0.24_linux_amd64.tar.gz"
+      sha256 "05684cbb7fb51c4695e52006a06fd8abdece1c41baba27d0867a4d3416491bb2"
+    end
+  end
+
+  on_macos do
+    stable do
+      url "https://github.com/fluxcd/toolkit/releases/download/v0.0.24/gotk_0.0.24_darwin_amd64.tar.gz"
+      sha256 "fcd6e68062bf811da031020ea7bb8640986b6407b66aa755af45d913e18c075e"
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/gotk 2>&1")
+    assert_match "Command line utility for assembling Kubernetes CD pipelines the GitOps way.", run_output
+
+    version_output = shell_output("#{bin}/gotk --version 2>&1")
+    assert_match version.to_s, version_output
+
+    system "#{bin}/gotk", "install", "--export"
+  end
+end

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -36,6 +36,9 @@ To configure your shell to load gotk completions add to your bash profile:
 . <(gotk completion)
 ```
 
+Users who wish to install the CLI via Homebrew instead may find alternate
+instructions on the [Installation](/guides/installation/#homebrew-installation) page.
+
 ## GitOps workflow
 
 You'll be using a dedicated Git repository e.g. `fleet-infra` to manage one or more Kubernetes clusters.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -8,6 +8,8 @@ to manage one or more Kubernetes clusters.
 You will need a Kubernetes cluster version **1.16** or newer
 and kubectl version **1.18** or newer.
 
+### Automatic Installation
+
 Install the toolkit CLI with:
 
 ```sh
@@ -17,6 +19,21 @@ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 The install script downloads the gotk binary to `/usr/local/bin`.
 Binaries for macOS and Linux AMD64/ARM64 are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
+
+### Homebrew Installation
+
+The toolkit CLI may alternatively be installed by MacOS or Linux users via
+[Homebrew](https://brew.sh/). This method is currently community-supported and may not provide the latest possible release.
+
+``` bash
+brew tap fluxcd/toolkit
+# Install latest tagged release
+brew install fluxcd/toolkit/gotk
+# Install unstable versions from source
+brew install --HEAD fluxcd/toolkit/gotk
+```
+
+### Cluster Requirements Check
 
 Verify that your cluster satisfies the prerequisites with:
 

--- a/install/README.md
+++ b/install/README.md
@@ -41,3 +41,31 @@ Run the binary:
 ```bash
 ./bin/gotk -h
 ```
+
+## Installation via Homebrew
+
+MacOS users (and Linux users who choose to adopt Homebrew) may install the
+`gotk` CLI via Homebrew as well. Installation instructions and prerequisites for
+Homebrew are documented on that tool's [home page](https://brew.sh/).
+
+``` bash
+brew tap fluxcd/toolkit
+# Install latest tagged release
+brew install fluxcd/toolkit/gotk
+# Install from source
+brew install --HEAD fluxcd/toolkit/gotk
+```
+
+Updated definitions for installing newer releases of `gotk` can be fetched once
+this repository has updated the formula by executing `brew update`. The
+availability of a possible upgrade can be checked using `brew outdated`. If a
+newer version is available, it may be installed using `brew upgrade
+fluxcd/toolkit/gotk` or prevented using `brew pin`. Please see the instructions
+for more details.
+
+### Uninstalling via Homebrew
+
+``` bash
+brew uninstall fluxcd/toolkit/gotk
+brew untap fluxcd/toolkit
+```


### PR DESCRIPTION
This PR implements one non-curl alternate as briefly discussed [here](https://github.com/fluxcd/toolkit/discussions/176), Homebrew. I use desktop Linux with low frequency as well, but it's primarily NixOS which does not use either APT/Yum that would be more broadly applicable. I don't know the prevalence of Linux adoption of Homebrew vs distributions' own package managers, but I attempted to include support for it here.

Planned content:
- [X] Homebrew formula
- [X] Documentation update covering this installation option

I'd also possibly be interested in implementing these if desired:
- [ ] (Optional) GitHub Action workflow to verify the viability of the formula

If left to my own devices, I'd base the above on the validation steps I followed below, or any recommended alternative steps that the maintainers prefer.

I don't personally feel well equipped to author an Action to update the formula automatically post-release with the checksums and URLs, but I can see that that is probably desirable to reduce the maintenance burden. I've not worked with Actions (or `GoReleaser`) anywhere near enough, though I could start to crib from the recent contribution that PRs updates of the sub-components and probably make decent headway.

Finally, if the folder structure of `./Formula/package-name.rb` does not suit for any reason, I think that's extremely flexible and would happily apply any replacement suggestion. Homebrew itself seems to care very little about the particulars as long as the files end in `.rb`.

---

I have never packaged software for Homebrew before, so any specific feedback to that format by others with more experience is especially welcome. I have previously worked with other package managers, `fpm`, etc. and have done my best to be thorough based on prior art.

I found the following resources helpful to reference during this work, which may also be useful for reviewers:
- [Upstream formula for fluxctl](https://github.com/Homebrew/homebrew-core/blob/b5d1ecb4880401bb4e2e8b9144ac87207d668467/Formula/fluxctl.rb)
- Homebrew docs
  - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
  - [Taps](https://docs.brew.sh/Taps)
  - [Homebrew On Linux](https://docs.brew.sh/Homebrew-on-Linux)
  - [How to Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap)
- [Ruby module doc for Formula class](https://www.rubydoc.info/github/Homebrew/brew/Formula)
- [This project's own `.goreleaser.yml` file](https://github.com/fluxcd/toolkit/blob/78bb11dcbf552518dbc5bc9d5e3147d6ed4d4740/.goreleaser.yml)

In order to simulate the `brew tap` experience with my fork, I've changed my default branch to the one that represents this PR. I'm not clear if or how one could ask `brew tap` to choose an alternate branch.

<details>
<summary>MacOS validation steps</summary>
Local experience:
```shell
brew install [--HEAD] ./Formula/gotk.rb
brew test [--HEAD] ./Formula/gotk.rb
```

Tap experience:
```shell
# If this work is merged, I believe this collapses to:
# brew tap fluxcd/toolkit
brew tap --debug --verbose fluxcd/toolkit https://github.com/shanesveller/fluxcd-toolkit.git
brew install [--HEAD] fluxcd/toolkit/gotk
brew test [--HEAD] fluxcd/toolkit/gotk
```
</details>

<details>
<summary>Linux validation steps</summary>

I ran these under `docker run -it --rm ubuntu:20.04` for expedience.

```shell
adduser brew-test --disabled-password --gecos ''
apt-get update && apt-get install -y --no-install-recommends build-essential curl gcc git
su - brew-test
# all remaining commands as brew-test
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
# (Ctrl-D) to skip the step requiring sudo
brew tap -d -v fluxcd/toolkit https://github.com/shanesveller/fluxcd-toolkit.git
brew install [--HEAD] fluxcd/toolkit/gotk
brew test [--HEAD] fluxcd/toolkit/gotk
```
<details>

All feedback is welcome from my POV, and thank you to all the maintainers for your work on this project.
