### PR TITLE
Publish Homebrew formula

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,3 +82,4 @@ jobs:
           args: release --release-notes=/tmp/release.txt --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,3 +15,19 @@ archives:
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - none*
+brews:
+  - tap:
+      owner: fluxcd
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
+    folder: Formula
+    homepage: "https://toolkit.fluxcd.io/"
+    description: "GitOps Toolkit CLI"
+
+    dependencies:
+      - name: kubectl
+        type: optional
+
+    test: |
+      system "#{bin}/gotk --version"

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -19,7 +19,15 @@ export GITHUB_USER=<your-username>
 
 ## Install the toolkit CLI
 
-To install the latest `gotk` release run:
+To install the latest `gotk` release on MacOS and Linux using
+[Homebrew](https://brew.sh/) run:
+
+```sh
+brew tap fluxcd/tap
+brew install gotk
+```
+
+Or install `gotk` by downloading precompiled binaries using a Bash script:
 
 ```sh
 curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
@@ -29,7 +37,7 @@ The install script downloads the gotk binary to `/usr/local/bin`.
 Binaries for macOS and Linux AMD64/ARM64 are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 
-To configure your shell to load gotk completions add to your bash profile:
+To configure your shell to load gotk completions add to your Bash profile:
 
 ```sh
 # ~/.bashrc or ~/.bash_profile

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -8,13 +8,24 @@ to manage one or more Kubernetes clusters.
 You will need a Kubernetes cluster version **1.16** or newer
 and kubectl version **1.18** or newer.
 
-Install the toolkit CLI with:
+## Install the toolkit CLI
+
+With Homebrew:
+
+```sh
+brew tap fluxcd/tap
+brew install gotk
+```
+
+With Bash:
 
 ```sh
 curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
+
+# enable completions in ~/.bash_profile
+. <(gotk completion)
 ```
 
-The install script downloads the gotk binary to `/usr/local/bin`.
 Binaries for macOS and Linux AMD64/ARM64 are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 


### PR DESCRIPTION
Changes:
- Publish Homebrew formula to [fluxcd/homebrew-tap](https://github.com/fluxcd/homebrew-tap) repo from CI with goreleaser 
- Add brew install instructions to docs
