### PR TITLE
Add label arg to create commands

### DIFF
--- a/cmd/gotk/create.go
+++ b/cmd/gotk/create.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,10 +33,26 @@ var createCmd = &cobra.Command{
 var (
 	interval time.Duration
 	export   bool
+	labels   []string
 )
 
 func init() {
 	createCmd.PersistentFlags().DurationVarP(&interval, "interval", "", time.Minute, "source sync interval")
 	createCmd.PersistentFlags().BoolVar(&export, "export", false, "export in YAML format to stdout")
+	createCmd.PersistentFlags().StringSliceVar(&labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
 	rootCmd.AddCommand(createCmd)
+}
+
+func parseLabels() (map[string]string, error) {
+	result := make(map[string]string)
+	for _, label := range labels {
+		parts := strings.Split(label, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid label format '%s', must be key=value", label)
+		}
+		result[parts[0]] = parts[1]
+	}
+
+	return result, nil
 }

--- a/cmd/gotk/create_kustomization.go
+++ b/cmd/gotk/create_kustomization.go
@@ -121,10 +121,16 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 		logger.Generatef("generating kustomization")
 	}
 
+	ksLabels, err := parseLabels()
+	if err != nil {
+		return err
+	}
+
 	kustomization := kustomizev1.Kustomization{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    ksLabels,
 		},
 		Spec: kustomizev1.KustomizationSpec{
 			DependsOn: ksDependsOn,
@@ -260,6 +266,7 @@ func upsertKustomization(ctx context.Context, kubeClient client.Client, kustomiz
 		return err
 	}
 
+	existing.Labels = kustomization.Labels
 	existing.Spec = kustomization.Spec
 	if err := kubeClient.Update(ctx, &existing); err != nil {
 		return err

--- a/cmd/gotk/create_source_git.go
+++ b/cmd/gotk/create_source_git.go
@@ -129,10 +129,16 @@ func createSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("git URL parse failed: %w", err)
 	}
 
+	sourceLabels, err := parseLabels()
+	if err != nil {
+		return err
+	}
+
 	gitRepository := sourcev1.GitRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    sourceLabels,
 		},
 		Spec: sourcev1.GitRepositorySpec{
 			URL: sourceGitURL,
@@ -343,6 +349,7 @@ func upsertGitRepository(ctx context.Context, kubeClient client.Client, gitRepos
 		return err
 	}
 
+	existing.Labels = gitRepository.Labels
 	existing.Spec = gitRepository.Spec
 	if err := kubeClient.Update(ctx, &existing); err != nil {
 		return err

--- a/cmd/gotk/export_helmrelease.go
+++ b/cmd/gotk/export_helmrelease.go
@@ -68,7 +68,7 @@ func exportHelmReleaseCmdRun(cmd *cobra.Command, args []string) error {
 		}
 
 		if len(list.Items) == 0 {
-			logger.Failuref("no kustomizations found in %s namespace", namespace)
+			logger.Failuref("no helmrelease found in %s namespace", namespace)
 			return nil
 		}
 
@@ -101,8 +101,10 @@ func exportHelmRelease(helmRelease helmv2.HelmRelease) error {
 			APIVersion: gvk.GroupVersion().String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmRelease.Name,
-			Namespace: helmRelease.Namespace,
+			Name:        helmRelease.Name,
+			Namespace:   helmRelease.Namespace,
+			Labels:      helmRelease.Labels,
+			Annotations: helmRelease.Annotations,
 		},
 		Spec: helmRelease.Spec,
 	}

--- a/cmd/gotk/export_kustomization.go
+++ b/cmd/gotk/export_kustomization.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1alpha1"
 )
 
 var exportKsCmd = &cobra.Command{
@@ -100,8 +101,10 @@ func exportKs(kustomization kustomizev1.Kustomization) error {
 			APIVersion: gvk.GroupVersion().String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kustomization.Name,
-			Namespace: kustomization.Namespace,
+			Name:        kustomization.Name,
+			Namespace:   kustomization.Namespace,
+			Labels:      kustomization.Labels,
+			Annotations: kustomization.Annotations,
 		},
 		Spec: kustomization.Spec,
 	}

--- a/cmd/gotk/export_source_git.go
+++ b/cmd/gotk/export_source_git.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1alpha1"
 )
 
 var exportSourceGitCmd = &cobra.Command{
@@ -110,8 +111,10 @@ func exportGit(source sourcev1.GitRepository) error {
 			APIVersion: gvk.GroupVersion().String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      source.Name,
-			Namespace: source.Namespace,
+			Name:        source.Name,
+			Namespace:   source.Namespace,
+			Labels:      source.Labels,
+			Annotations: source.Annotations,
 		},
 		Spec: source.Spec,
 	}

--- a/cmd/gotk/export_source_helm.go
+++ b/cmd/gotk/export_source_helm.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1alpha1"
 )
 
 var exportSourceHelmCmd = &cobra.Command{
@@ -99,6 +100,32 @@ func exportSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 			return exportHelmCredentials(ctx, kubeClient, repository)
 		}
 	}
+	return nil
+}
+
+func exportHelmRepository(source sourcev1.HelmRepository) error {
+	gvk := sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)
+	export := sourcev1.HelmRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        source.Name,
+			Namespace:   source.Namespace,
+			Labels:      source.Labels,
+			Annotations: source.Annotations,
+		},
+		Spec: source.Spec,
+	}
+
+	data, err := yaml.Marshal(export)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("---")
+	fmt.Println(string(data))
 	return nil
 }
 

--- a/docs/cmd/gotk_create.md
+++ b/docs/cmd/gotk_create.md
@@ -12,6 +12,7 @@ The create sub-commands generate sources and resources.
       --export              export in YAML format to stdout
   -h, --help                help for create
       --interval duration   source sync interval (default 1m0s)
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/gotk_create_helmrelease.md
+++ b/docs/cmd/gotk_create_helmrelease.md
@@ -72,6 +72,7 @@ gotk create helmrelease [name] [flags]
       --export              export in YAML format to stdout
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
       --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_create_kustomization.md
+++ b/docs/cmd/gotk_create_kustomization.md
@@ -68,6 +68,7 @@ gotk create kustomization [name] [flags]
       --export              export in YAML format to stdout
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
       --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_create_source.md
+++ b/docs/cmd/gotk_create_source.md
@@ -18,6 +18,7 @@ The create source sub-commands generate sources.
       --export              export in YAML format to stdout
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
       --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_create_source_git.md
+++ b/docs/cmd/gotk_create_source_git.md
@@ -73,6 +73,7 @@ gotk create source git [name] [flags]
       --export              export in YAML format to stdout
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
       --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_create_source_helm.md
+++ b/docs/cmd/gotk_create_source_helm.md
@@ -53,6 +53,7 @@ gotk create source helm [name] [flags]
       --export              export in YAML format to stdout
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
       --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects


### PR DESCRIPTION
This PR adds support for defining labels when creating or updating the toolkit resources.

Example:

```sh
gotk create source git podinfo \
--url=https://github.com/stefanprodan/podinfo \
--label=toolkit.fluxcd.io/env=dev \
--label=toolkit.fluxcd.io/role=app
```