### PR TITLE
Add branch flag to bootstrap cmd

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -29,7 +29,15 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Build
         run: sudo go build -o ./bin/gotk ./cmd/gotk
-      - name: gotk bootstrap github
+      - name: bootstrap init
+        run: |
+          ./bin/gotk bootstrap github \
+          --owner=fluxcd-testing \
+          --repository=gotk-test-${{ steps.vars.outputs.sha_short }} \
+          --path=test-cluster
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
+      - name: bootstrap no-op
         run: |
           ./bin/gotk bootstrap github \
           --owner=fluxcd-testing \
@@ -41,6 +49,14 @@ jobs:
         run: |
           ./bin/gotk suspend kustomization gitops-system
           ./bin/gotk uninstall --resources --crds -s
+      - name: bootstrap reinstall
+        run: |
+          ./bin/gotk bootstrap github \
+          --owner=fluxcd-testing \
+          --repository=gotk-test-${{ steps.vars.outputs.sha_short }} \
+          --path=test-cluster
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: delete repository
         run: |
           ./bin/gotk bootstrap github \

--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -72,7 +72,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapArch, "arch", "amd64",
 		"arch can be amd64 or arm64")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapBranch, "branch", bootstrapDefaultBranch,
-		"default branch (for GitHub this must match the organization default branch setting)")
+		"default branch (for GitHub this must match the default branch setting for the organization)")
 	rootCmd.AddCommand(bootstrapCmd)
 }
 

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -10,7 +10,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
-      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
+      --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -10,6 +10,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
+      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -35,6 +35,9 @@ gotk bootstrap github [flags]
   # Run bootstrap for a private repo hosted on GitHub Enterprise
   gotk bootstrap github --owner=<organization> --repository=<repo name> --hostname=<domain>
 
+  # Run bootstrap for a an existing repository with a branch named main
+  gotk bootstrap github --owner=<organization> --repository=<repo name> --branch=main
+
 ```
 
 ### Options
@@ -55,6 +58,7 @@ gotk bootstrap github [flags]
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
+      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -58,7 +58,7 @@ gotk bootstrap github [flags]
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
-      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
+      --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -55,7 +55,7 @@ gotk bootstrap gitlab [flags]
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
-      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
+      --branch string              default branch (for GitHub this must match the default branch setting for the organization) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -32,6 +32,9 @@ gotk bootstrap gitlab [flags]
   # Run bootstrap for a private repo hosted on a GitLab server 
   gotk bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain>
 
+  # Run bootstrap for a an existing repository with a branch named main
+  gotk bootstrap gitlab --owner=<organization> --repository=<repo name> --branch=main
+
 ```
 
 ### Options
@@ -52,6 +55,7 @@ gotk bootstrap gitlab [flags]
 
 ```
       --arch string                arch can be amd64 or arm64 (default "amd64")
+      --branch string              default branch (for GitHub this must match the organization default branch setting) (default "master")
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -79,6 +79,10 @@ cluster e.g. `staging-cluster` and `production-cluster`:
     └── gitops-system
 ``` 
 
+!!! hint "Change the default branch"
+    If you wish to change the branch to something else than master, create the repository manually,
+    push a branch to origin and then use `gotk bootstrap <GIT-PROVIDER> --branch=your-branch`.
+
 ### GitHub and GitHub Enterprise
 
 Generate a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)


### PR DESCRIPTION
This allows changing the bootstrap branch name for existing repositories or when the GitHub organization default branch is set to something else than master.
 
Fix: #169