### PR TITLE
Add PATCH rule to crd-controller role for events

### DIFF
--- a/manifests/rbac/role.yaml
+++ b/manifests/rbac/role.yaml
@@ -27,6 +27,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
During high custom resource count / low interval tests, I was greated
with a `cannot patch resource "events"` message. This happened due to
event compaction, where it will perform a patch instead of a create.
By giving the role the permission to do so this should no longer pose
a problem.