### PR TITLE
Add watch all namespaces flag

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -45,12 +45,13 @@ var bootstrapCmd = &cobra.Command{
 }
 
 var (
-	bootstrapVersion         string
-	bootstrapComponents      []string
-	bootstrapRegistry        string
-	bootstrapImagePullSecret string
-	bootstrapArch            string
-	bootstrapBranch          string
+	bootstrapVersion            string
+	bootstrapComponents         []string
+	bootstrapRegistry           string
+	bootstrapImagePullSecret    string
+	bootstrapArch               string
+	bootstrapBranch             string
+	bootstrapWatchAllNamespaces bool
 )
 
 const (
@@ -74,6 +75,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapBranch, "branch", bootstrapDefaultBranch,
 		"default branch (for GitHub this must match the default branch setting for the organization)")
 	rootCmd.AddCommand(bootstrapCmd)
+	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapWatchAllNamespaces, "watch-all-namespaces", true,
+		"watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed")
 }
 
 func generateInstallManifests(targetPath, namespace, tmpDir string) (string, error) {
@@ -84,7 +87,8 @@ func generateInstallManifests(targetPath, namespace, tmpDir string) (string, err
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 
-	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents, bootstrapRegistry, bootstrapImagePullSecret, bootstrapArch, gotkDir); err != nil {
+	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents,
+		bootstrapWatchAllNamespaces, bootstrapRegistry, bootstrapImagePullSecret, bootstrapArch, gotkDir); err != nil {
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -16,6 +16,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
+      --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -67,6 +67,7 @@ gotk bootstrap github [flags]
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")
+      --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -64,6 +64,7 @@ gotk bootstrap gitlab [flags]
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects
   -v, --version string             toolkit version (default "latest")
+      --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -40,6 +40,7 @@ gotk install [flags]
       --manifests string           path to the manifest directory, dev only
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
+      --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This PR adds the `--watch-all-namespaces` flag to gotk install and bootstrap commands. 

With  `--watch-all-namespaces` (defaults to `true`) users can configure the toolkit controllers to watch for custom resources in all namespaces, if set to `false` it will only watch the namespace where the toolkit is installed.

Fix: #224