### PR TITLE
Add log level flag

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -52,6 +52,7 @@ var (
 	bootstrapArch               string
 	bootstrapBranch             string
 	bootstrapWatchAllNamespaces bool
+	bootstrapLogLevel           string
 )
 
 const (
@@ -77,6 +78,19 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapWatchAllNamespaces, "watch-all-namespaces", true,
 		"watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapLogLevel, "log-level", "info", "set the controllers log level")
+}
+
+func bootstrapValidate() error {
+	if !utils.containsItemString(supportedArch, bootstrapArch) {
+		return fmt.Errorf("arch %s is not supported, can be %v", bootstrapArch, supportedArch)
+	}
+
+	if !utils.containsItemString(supportedLogLevels, bootstrapLogLevel) {
+		return fmt.Errorf("log level %s is not supported, can be %v", bootstrapLogLevel, supportedLogLevels)
+	}
+
+	return nil
 }
 
 func generateInstallManifests(targetPath, namespace, tmpDir string) (string, error) {
@@ -88,7 +102,8 @@ func generateInstallManifests(targetPath, namespace, tmpDir string) (string, err
 	}
 
 	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents,
-		bootstrapWatchAllNamespaces, bootstrapRegistry, bootstrapImagePullSecret, bootstrapArch, gotkDir); err != nil {
+		bootstrapWatchAllNamespaces, bootstrapRegistry, bootstrapImagePullSecret,
+		bootstrapArch, bootstrapLogLevel, gotkDir); err != nil {
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}
 

--- a/cmd/gotk/bootstrap_github.go
+++ b/cmd/gotk/bootstrap_github.go
@@ -100,8 +100,8 @@ func bootstrapGitHubCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s environment variable not found", git.GitHubTokenName)
 	}
 
-	if !utils.containsItemString(supportedArch, bootstrapArch) {
-		return fmt.Errorf("arch %s is not supported, can be %v", bootstrapArch, supportedArch)
+	if err := bootstrapValidate(); err != nil {
+		return err
 	}
 
 	repository, err := git.NewRepository(ghRepository, ghOwner, ghHostname, ghToken, "gotk", ghOwner+"@users.noreply.github.com")

--- a/cmd/gotk/bootstrap_gitlab.go
+++ b/cmd/gotk/bootstrap_gitlab.go
@@ -89,8 +89,8 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s environment variable not found", git.GitLabTokenName)
 	}
 
-	if !utils.containsItemString(supportedArch, bootstrapArch) {
-		return fmt.Errorf("arch %s is not supported, can be %v", bootstrapArch, supportedArch)
+	if err := bootstrapValidate(); err != nil {
+		return err
 	}
 
 	repository, err := git.NewRepository(glRepository, glOwner, glHostname, glToken, "gotk", glOwner+"@users.noreply.gitlab.com")

--- a/cmd/gotk/main.go
+++ b/cmd/gotk/main.go
@@ -113,6 +113,7 @@ var (
 	supportedArch                 = []string{"arm64", "amd64"}
 	supportedDecryptionProviders  = []string{"sops"}
 	supportedHelmChartSourceKinds = []string{sourcev1.HelmRepositoryKind, sourcev1.GitRepositoryKind}
+	supportedLogLevels            = []string{"debug", "info", "error"}
 )
 
 func init() {

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -14,6 +14,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --log-level string           set the controllers log level (default "info")
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -62,6 +62,7 @@ gotk bootstrap github [flags]
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
+      --log-level string           set the controllers log level (default "info")
       --namespace string           the namespace scope for this operation (default "gitops-system")
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -59,6 +59,7 @@ gotk bootstrap gitlab [flags]
       --components strings         list of components, accepts comma-separated values (default [source-controller,kustomize-controller,helm-controller,notification-controller])
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
+      --log-level string           set the controllers log level (default "info")
       --namespace string           the namespace scope for this operation (default "gitops-system")
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -37,6 +37,7 @@ gotk install [flags]
       --export                     write the install manifests to stdout and exit
   -h, --help                       help for install
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
+      --log-level string           set the controllers log level (default "info")
       --manifests string           path to the manifest directory, dev only
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")


### PR DESCRIPTION
This PR adds the `--log-level` flag (defaults to `info`) to gotk install and bootstrap commands.