### PR TITLE
Support bash, fish, zsh, and powershell shell completions as separate sub-commands

### DIFF
--- a/cmd/gotk/completion_bash.go
+++ b/cmd/gotk/completion_bash.go
@@ -17,15 +17,28 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates completion scripts for various shells",
-	Long:  "The completion sub-command generates completion scripts for various shells",
+var completionBashCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "Generates bash completion scripts",
+	Example: `To load completion run
+
+. <(gotk completion bash)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+command -v gotk >/dev/null && . <(gotk completion bash)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenBashCompletion(os.Stdout)
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(completionCmd)
+	completionCmd.AddCommand(completionBashCmd)
 }

--- a/cmd/gotk/completion_fish.go
+++ b/cmd/gotk/completion_fish.go
@@ -17,15 +17,29 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates completion scripts for various shells",
-	Long:  "The completion sub-command generates completion scripts for various shells",
+var completionFishCmd = &cobra.Command{
+	Use:   "fish",
+	Short: "Generates fish completion scripts",
+	Example: `To load completion run
+
+. <(gotk completion fish)
+
+To configure your fish shell to load completions for each session write this script to your completions dir:
+
+gotk completion fish > ~/.config/fish/completions/gotk
+
+See http://fishshell.com/docs/current/index.html#completion-own for more details
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenFishCompletion(os.Stdout, true)
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(completionCmd)
+	completionCmd.AddCommand(completionFishCmd)
 }

--- a/cmd/gotk/completion_powershell.go
+++ b/cmd/gotk/completion_powershell.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionPowerShellCmd = &cobra.Command{
+	Use:   "powershell",
+	Short: "Generates powershell completion scripts",
+	Example: `To load completion run
+
+. <(gotk completion powershell)
+
+To configure your powershell shell to load completions for each session add to your powershell profile
+
+Windows:
+
+cd "$env:USERPROFILE\Documents\WindowsPowerShell\Modules"
+gotk completion >> gotk-completion.ps1
+
+Linux:
+
+cd "${XDG_CONFIG_HOME:-"$HOME/.config/"}/powershell/modules"
+gotk completion >> gotk-completions.ps1
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenPowerShellCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	completionCmd.AddCommand(completionPowerShellCmd)
+}

--- a/cmd/gotk/completion_zsh.go
+++ b/cmd/gotk/completion_zsh.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionZshCmd = &cobra.Command{
+	Use:   "zsh",
+	Short: "Generates zsh completion scripts",
+	Example: `To load completion run
+
+. <(gotk completion zsh) && compdef _gotk gotk
+
+To configure your zsh shell to load completions for each session add to your zshrc
+
+# ~/.zshrc or ~/.profile
+command -v gotk >/dev/null && . <(gotk completion zsh) && compdef _gotk gotk
+
+or write a cached file in one of the completion directories in your ${fpath}:
+
+echo "${fpath// /\n}" | grep -i completion
+gotk completions zsh > _gotk
+
+mv _gotk ~/.oh-my-zsh/completions  # oh-my-zsh
+mv _gotk ~/.zprezto/modules/completion/external/src/  # zprezto
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenZshCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	completionCmd.AddCommand(completionZshCmd)
+}

--- a/docs/cmd/gotk.md
+++ b/docs/cmd/gotk.md
@@ -78,7 +78,7 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.
 
 * [gotk bootstrap](gotk_bootstrap.md)	 - Bootstrap toolkit components
 * [gotk check](gotk_check.md)	 - Check requirements and installation
-* [gotk completion](gotk_completion.md)	 - Generates bash completion scripts
+* [gotk completion](gotk_completion.md)	 - Generates completion scripts for various shells
 * [gotk create](gotk_create.md)	 - Create or update sources and resources
 * [gotk delete](gotk_delete.md)	 - Delete sources and resources
 * [gotk export](gotk_export.md)	 - Export resources in YAML format

--- a/docs/cmd/gotk_completion.md
+++ b/docs/cmd/gotk_completion.md
@@ -1,28 +1,10 @@
 ## gotk completion
 
-Generates bash completion scripts
+Generates completion scripts for various shells
 
 ### Synopsis
 
-Generates bash completion scripts
-
-```
-gotk completion [flags]
-```
-
-### Examples
-
-```
-To load completion run
-
-. <(gotk completion)
-
-To configure your bash shell to load completions for each session add to your bashrc
-
-# ~/.bashrc or ~/.profile
-. <(gotk completion)
-
-```
+The completion sub-command generates completion scripts for various shells
 
 ### Options
 
@@ -42,4 +24,8 @@ To configure your bash shell to load completions for each session add to your ba
 ### SEE ALSO
 
 * [gotk](gotk.md)	 - Command line utility for assembling Kubernetes CD pipelines
+* [gotk completion bash](gotk_completion_bash.md)	 - Generates bash completion scripts
+* [gotk completion fish](gotk_completion_fish.md)	 - Generates fish completion scripts
+* [gotk completion powershell](gotk_completion_powershell.md)	 - Generates powershell completion scripts
+* [gotk completion zsh](gotk_completion_zsh.md)	 - Generates zsh completion scripts
 

--- a/docs/cmd/gotk_completion_bash.md
+++ b/docs/cmd/gotk_completion_bash.md
@@ -1,0 +1,45 @@
+## gotk completion bash
+
+Generates bash completion scripts
+
+### Synopsis
+
+Generates bash completion scripts
+
+```
+gotk completion bash [flags]
+```
+
+### Examples
+
+```
+To load completion run
+
+. <(gotk completion bash)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+command -v gotk >/dev/null && . <(gotk completion bash)
+
+```
+
+### Options
+
+```
+  -h, --help   help for bash
+```
+
+### Options inherited from parent commands
+
+```
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --namespace string    the namespace scope for this operation (default "gitops-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [gotk completion](gotk_completion.md)	 - Generates completion scripts for various shells
+

--- a/docs/cmd/gotk_completion_fish.md
+++ b/docs/cmd/gotk_completion_fish.md
@@ -1,0 +1,46 @@
+## gotk completion fish
+
+Generates fish completion scripts
+
+### Synopsis
+
+Generates fish completion scripts
+
+```
+gotk completion fish [flags]
+```
+
+### Examples
+
+```
+To load completion run
+
+. <(gotk completion fish)
+
+To configure your fish shell to load completions for each session write this script to your completions dir:
+
+gotk completion fish > ~/.config/fish/completions/gotk
+
+See http://fishshell.com/docs/current/index.html#completion-own for more details
+
+```
+
+### Options
+
+```
+  -h, --help   help for fish
+```
+
+### Options inherited from parent commands
+
+```
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --namespace string    the namespace scope for this operation (default "gitops-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [gotk completion](gotk_completion.md)	 - Generates completion scripts for various shells
+

--- a/docs/cmd/gotk_completion_powershell.md
+++ b/docs/cmd/gotk_completion_powershell.md
@@ -1,0 +1,52 @@
+## gotk completion powershell
+
+Generates powershell completion scripts
+
+### Synopsis
+
+Generates powershell completion scripts
+
+```
+gotk completion powershell [flags]
+```
+
+### Examples
+
+```
+To load completion run
+
+. <(gotk completion powershell)
+
+To configure your powershell shell to load completions for each session add to your powershell profile
+
+Windows:
+
+cd "$env:USERPROFILE\Documents\WindowsPowerShell\Modules"
+gotk completion >> gotk-completion.ps1
+
+Linux:
+
+cd "${XDG_CONFIG_HOME:-"$HOME/.config/"}/powershell/modules"
+gotk completion >> gotk-completions.ps1
+
+```
+
+### Options
+
+```
+  -h, --help   help for powershell
+```
+
+### Options inherited from parent commands
+
+```
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --namespace string    the namespace scope for this operation (default "gitops-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [gotk completion](gotk_completion.md)	 - Generates completion scripts for various shells
+

--- a/docs/cmd/gotk_completion_zsh.md
+++ b/docs/cmd/gotk_completion_zsh.md
@@ -1,0 +1,53 @@
+## gotk completion zsh
+
+Generates zsh completion scripts
+
+### Synopsis
+
+Generates zsh completion scripts
+
+```
+gotk completion zsh [flags]
+```
+
+### Examples
+
+```
+To load completion run
+
+. <(gotk completion zsh) && compdef _gotk gotk
+
+To configure your zsh shell to load completions for each session add to your zshrc
+
+# ~/.zshrc or ~/.profile
+command -v gotk >/dev/null && . <(gotk completion zsh) && compdef _gotk gotk
+
+or write a cached file in one of the completion directories in your ${fpath}:
+
+echo "${fpath// /\n}" | grep -i completion
+gotk completions zsh > _gotk
+
+mv _gotk ~/.oh-my-zsh/completions  # oh-my-zsh
+mv _gotk ~/.zprezto/modules/completion/external/src/  # zprezto
+
+```
+
+### Options
+
+```
+  -h, --help   help for zsh
+```
+
+### Options inherited from parent commands
+
+```
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --namespace string    the namespace scope for this operation (default "gitops-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [gotk completion](gotk_completion.md)	 - Generates completion scripts for various shells
+

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -41,8 +41,10 @@ To configure your shell to load gotk completions add to your Bash profile:
 
 ```sh
 # ~/.bashrc or ~/.bash_profile
-. <(gotk completion)
+. <(gotk completion bash)
 ```
+
+`zsh`, `fish`, and `powershell` are also supported with their own sub-commands.
 
 ## GitOps workflow
 


### PR DESCRIPTION
Was running through the `get-started.md` and noticed we didn't have zsh support.
I use zsh, so I figured I'd add it along /w Cobra's other supported shells.

This sub-command approach is the same one used by `kind`.
It's also similar to `kubectl`, except they just use an argument instead of dedicated sub-commands.