### PR TITLE
Add create tenant command

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - docs*
-      - master
+    tags:
+      - '*'
 
 jobs:
   build:

--- a/cmd/gotk/create_kustomization.go
+++ b/cmd/gotk/create_kustomization.go
@@ -179,9 +179,8 @@ func createKsCmdRun(cmd *cobra.Command, args []string) error {
 				Namespace: nameNs[1],
 			}
 
-			//TODO: (stefan) define the API version as a constant in the API package
 			if kind == helmv2.HelmReleaseKind {
-				check.APIVersion = "helm.toolkit.fluxcd.io/v2alpha1"
+				check.APIVersion = helmv2.GroupVersion.String()
 			}
 			healthChecks = append(healthChecks, check)
 		}

--- a/cmd/gotk/create_tenant.go
+++ b/cmd/gotk/create_tenant.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var createTenantCmd = &cobra.Command{
+	Use:   "tenant",
+	Short: "Create or update a tenant",
+	Long: `
+The create tenant command generates a namespace and a role binding to limit the
+reconcilers scope to the tenant namespace.`,
+	RunE: createTenantCmdRun,
+}
+
+func init() {
+	createCmd.AddCommand(createTenantCmd)
+}
+
+func createTenantCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("tenant name is required")
+	}
+	tenant := args[0]
+
+	objLabels, err := parseLabels()
+	if err != nil {
+		return err
+	}
+
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   tenant,
+			Labels: objLabels,
+		},
+	}
+
+	roleBinding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gotk-reconciler",
+			Namespace: tenant,
+			Labels:    objLabels,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "User",
+				Name:     fmt.Sprintf("gotk:%s:reconciler", tenant),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	}
+
+	if export {
+		return exportTenant(namespace, roleBinding)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	kubeClient, err := utils.kubeClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	logger.Actionf("applying namespace %s", namespace.Name)
+	if err := upsertNamespace(ctx, kubeClient, namespace); err != nil {
+		return err
+	}
+
+	logger.Actionf("applying role binding %s", roleBinding.Name)
+	if err := upsertRoleBinding(ctx, kubeClient, roleBinding); err != nil {
+		return err
+	}
+
+	logger.Successf("tenant setup completed")
+	return nil
+}
+
+func upsertNamespace(ctx context.Context, kubeClient client.Client, namespace corev1.Namespace) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace.GetNamespace(),
+		Name:      namespace.GetName(),
+	}
+
+	var existing corev1.Namespace
+	err := kubeClient.Get(ctx, namespacedName, &existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := kubeClient.Create(ctx, &namespace); err != nil {
+				return err
+			} else {
+				return nil
+			}
+		}
+		return err
+	}
+
+	if !equality.Semantic.DeepDerivative(namespace.Labels, existing.Labels) {
+		existing.Labels = namespace.Labels
+		if err := kubeClient.Update(ctx, &existing); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func upsertRoleBinding(ctx context.Context, kubeClient client.Client, roleBinding rbacv1.RoleBinding) error {
+	namespacedName := types.NamespacedName{
+		Namespace: roleBinding.GetNamespace(),
+		Name:      roleBinding.GetName(),
+	}
+
+	var existing rbacv1.RoleBinding
+	err := kubeClient.Get(ctx, namespacedName, &existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := kubeClient.Create(ctx, &roleBinding); err != nil {
+				return err
+			} else {
+				return nil
+			}
+		}
+		return err
+	}
+
+	if !equality.Semantic.DeepDerivative(roleBinding.Subjects, existing.Subjects) ||
+		!equality.Semantic.DeepDerivative(roleBinding.RoleRef, existing.RoleRef) ||
+		!equality.Semantic.DeepDerivative(roleBinding.Labels, existing.Labels) {
+		if err := kubeClient.Delete(ctx, &existing); err != nil {
+			return err
+		}
+		if err := kubeClient.Create(ctx, &roleBinding); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func exportTenant(namespace corev1.Namespace, roleBinding rbacv1.RoleBinding) error {
+	namespace.TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+	}
+	data, err := yaml.Marshal(namespace)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("---")
+	data = bytes.Replace(data, []byte("spec: {}\n"), []byte(""), 1)
+	fmt.Println(resourceToString(data))
+
+	roleBinding.TypeMeta = metav1.TypeMeta{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "RoleBinding",
+	}
+	data, err = yaml.Marshal(roleBinding)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("---")
+	fmt.Println(resourceToString(data))
+
+	return nil
+}

--- a/cmd/gotk/export.go
+++ b/cmd/gotk/export.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+
 	"github.com/spf13/cobra"
 )
 
@@ -34,4 +36,10 @@ func init() {
 	exportCmd.PersistentFlags().BoolVar(&exportAll, "all", false, "select all resources")
 
 	rootCmd.AddCommand(exportCmd)
+}
+
+func resourceToString(data []byte) string {
+	data = bytes.Replace(data, []byte("creationTimestamp: null\n"), []byte(""), 1)
+	data = bytes.Replace(data, []byte("status: {}\n"), []byte(""), 1)
+	return string(data)
 }

--- a/cmd/gotk/export_helmrelease.go
+++ b/cmd/gotk/export_helmrelease.go
@@ -115,6 +115,6 @@ func exportHelmRelease(helmRelease helmv2.HelmRelease) error {
 	}
 
 	fmt.Println("---")
-	fmt.Println(string(data))
+	fmt.Println(resourceToString(data))
 	return nil
 }

--- a/cmd/gotk/export_kustomization.go
+++ b/cmd/gotk/export_kustomization.go
@@ -115,6 +115,6 @@ func exportKs(kustomization kustomizev1.Kustomization) error {
 	}
 
 	fmt.Println("---")
-	fmt.Println(string(data))
+	fmt.Println(resourceToString(data))
 	return nil
 }

--- a/cmd/gotk/export_source_git.go
+++ b/cmd/gotk/export_source_git.go
@@ -125,7 +125,7 @@ func exportGit(source sourcev1.GitRepository) error {
 	}
 
 	fmt.Println("---")
-	fmt.Println(string(data))
+	fmt.Println(resourceToString(data))
 	return nil
 }
 
@@ -160,7 +160,7 @@ func exportGitCredentials(ctx context.Context, kubeClient client.Client, source 
 		}
 
 		fmt.Println("---")
-		fmt.Println(string(data))
+		fmt.Println(resourceToString(data))
 	}
 	return nil
 }

--- a/cmd/gotk/export_source_helm.go
+++ b/cmd/gotk/export_source_helm.go
@@ -125,7 +125,7 @@ func exportHelmRepository(source sourcev1.HelmRepository) error {
 	}
 
 	fmt.Println("---")
-	fmt.Println(string(data))
+	fmt.Println(resourceToString(data))
 	return nil
 }
 
@@ -160,7 +160,7 @@ func exportHelmCredentials(ctx context.Context, kubeClient client.Client, source
 		}
 
 		fmt.Println("---")
-		fmt.Println(string(data))
+		fmt.Println(resourceToString(data))
 	}
 	return nil
 }

--- a/cmd/gotk/main.go
+++ b/cmd/gotk/main.go
@@ -117,12 +117,9 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&namespace, "namespace", defaultNamespace,
-		"the namespace scope for this operation")
-	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 5*time.Minute,
-		"timeout for this operation")
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false,
-		"print generated objects")
+	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", defaultNamespace, "the namespace scope for this operation")
+	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for this operation")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "print generated objects")
 }
 
 func main() {

--- a/cmd/gotk/utils.go
+++ b/cmd/gotk/utils.go
@@ -27,6 +27,7 @@ import (
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,6 +119,7 @@ func (*Utils) kubeClient(config string) (client.Client, error) {
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 	_ = sourcev1.AddToScheme(scheme)
 	_ = kustomizev1.AddToScheme(scheme)
 	_ = helmv2.AddToScheme(scheme)

--- a/docs/cmd/gotk.md
+++ b/docs/cmd/gotk.md
@@ -69,7 +69,7 @@ Command line utility for assembling Kubernetes CD pipelines the GitOps way.
 ```
   -h, --help                help for gotk
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -24,7 +24,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -63,7 +63,7 @@ gotk bootstrap github [flags]
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --log-level string           set the controllers log level (default "info")
-      --namespace string           the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string           the namespace scope for this operation (default "gitops-system")
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -60,7 +60,7 @@ gotk bootstrap gitlab [flags]
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --log-level string           set the controllers log level (default "info")
-      --namespace string           the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string           the namespace scope for this operation (default "gitops-system")
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects

--- a/docs/cmd/gotk_check.md
+++ b/docs/cmd/gotk_check.md
@@ -34,7 +34,7 @@ gotk check [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_completion.md
+++ b/docs/cmd/gotk_completion.md
@@ -16,7 +16,7 @@ The completion sub-command generates completion scripts for various shells
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_completion_bash.md
+++ b/docs/cmd/gotk_completion_bash.md
@@ -34,7 +34,7 @@ command -v gotk >/dev/null && . <(gotk completion bash)
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_completion_fish.md
+++ b/docs/cmd/gotk_completion_fish.md
@@ -35,7 +35,7 @@ See http://fishshell.com/docs/current/index.html#completion-own for more details
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_completion_powershell.md
+++ b/docs/cmd/gotk_completion_powershell.md
@@ -41,7 +41,7 @@ gotk completion >> gotk-completions.ps1
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_completion_zsh.md
+++ b/docs/cmd/gotk_completion_zsh.md
@@ -42,7 +42,7 @@ mv _gotk ~/.zprezto/modules/completion/external/src/  # zprezto
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create.md
+++ b/docs/cmd/gotk_create.md
@@ -19,7 +19,7 @@ The create sub-commands generate sources and resources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create.md
+++ b/docs/cmd/gotk_create.md
@@ -30,4 +30,5 @@ The create sub-commands generate sources and resources.
 * [gotk create helmrelease](gotk_create_helmrelease.md)	 - Create or update a HelmRelease resource
 * [gotk create kustomization](gotk_create_kustomization.md)	 - Create or update a Kustomization resource
 * [gotk create source](gotk_create_source.md)	 - Create or update sources
+* [gotk create tenant](gotk_create_tenant.md)	 - Create or update a tenant
 

--- a/docs/cmd/gotk_create_helmrelease.md
+++ b/docs/cmd/gotk_create_helmrelease.md
@@ -73,7 +73,7 @@ gotk create helmrelease [name] [flags]
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_kustomization.md
+++ b/docs/cmd/gotk_create_kustomization.md
@@ -69,7 +69,7 @@ gotk create kustomization [name] [flags]
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_source.md
+++ b/docs/cmd/gotk_create_source.md
@@ -19,7 +19,7 @@ The create source sub-commands generate sources.
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_source_git.md
+++ b/docs/cmd/gotk_create_source_git.md
@@ -74,7 +74,7 @@ gotk create source git [name] [flags]
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_source_helm.md
+++ b/docs/cmd/gotk_create_source_helm.md
@@ -54,7 +54,7 @@ gotk create source helm [name] [flags]
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_tenant.md
+++ b/docs/cmd/gotk_create_tenant.md
@@ -25,7 +25,7 @@ gotk create tenant [flags]
       --interval duration   source sync interval (default 1m0s)
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
       --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_create_tenant.md
+++ b/docs/cmd/gotk_create_tenant.md
@@ -1,0 +1,36 @@
+## gotk create tenant
+
+Create or update a tenant
+
+### Synopsis
+
+
+The create tenant command generates a namespace and a role binding to limit the
+reconcilers scope to the tenant namespace.
+
+```
+gotk create tenant [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for tenant
+```
+
+### Options inherited from parent commands
+
+```
+      --export              export in YAML format to stdout
+      --interval duration   source sync interval (default 1m0s)
+      --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
+      --label strings       set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)
+      --namespace string    the namespace scope for this operation (default "gitops-system")
+      --timeout duration    timeout for this operation (default 5m0s)
+      --verbose             print generated objects
+```
+
+### SEE ALSO
+
+* [gotk create](gotk_create.md)	 - Create or update sources and resources
+

--- a/docs/cmd/gotk_delete.md
+++ b/docs/cmd/gotk_delete.md
@@ -17,7 +17,7 @@ The delete sub-commands delete sources and resources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_delete_helmrelease.md
+++ b/docs/cmd/gotk_delete_helmrelease.md
@@ -28,7 +28,7 @@ gotk delete helmrelease [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
   -s, --silent              delete resource without asking for confirmation
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_delete_kustomization.md
+++ b/docs/cmd/gotk_delete_kustomization.md
@@ -28,7 +28,7 @@ gotk delete kustomization [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
   -s, --silent              delete resource without asking for confirmation
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_delete_source.md
+++ b/docs/cmd/gotk_delete_source.md
@@ -16,7 +16,7 @@ The delete source sub-commands delete sources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
   -s, --silent              delete resource without asking for confirmation
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_delete_source_git.md
+++ b/docs/cmd/gotk_delete_source_git.md
@@ -28,7 +28,7 @@ gotk delete source git [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
   -s, --silent              delete resource without asking for confirmation
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_delete_source_helm.md
+++ b/docs/cmd/gotk_delete_source_helm.md
@@ -28,7 +28,7 @@ gotk delete source helm [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
   -s, --silent              delete resource without asking for confirmation
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects

--- a/docs/cmd/gotk_export.md
+++ b/docs/cmd/gotk_export.md
@@ -17,7 +17,7 @@ The export sub-commands export resources in YAML format.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_export_helmrelease.md
+++ b/docs/cmd/gotk_export_helmrelease.md
@@ -32,7 +32,7 @@ gotk export helmrelease [name] [flags]
 ```
       --all                 select all resources
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_export_kustomization.md
+++ b/docs/cmd/gotk_export_kustomization.md
@@ -32,7 +32,7 @@ gotk export kustomization [name] [flags]
 ```
       --all                 select all resources
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_export_source.md
+++ b/docs/cmd/gotk_export_source.md
@@ -18,7 +18,7 @@ The export source sub-commands export sources in YAML format.
 ```
       --all                 select all resources
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_export_source_git.md
+++ b/docs/cmd/gotk_export_source_git.md
@@ -32,7 +32,7 @@ gotk export source git [name] [flags]
 ```
       --all                 select all resources
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
       --with-credentials    include credential secrets

--- a/docs/cmd/gotk_export_source_helm.md
+++ b/docs/cmd/gotk_export_source_helm.md
@@ -32,7 +32,7 @@ gotk export source helm [name] [flags]
 ```
       --all                 select all resources
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
       --with-credentials    include credential secrets

--- a/docs/cmd/gotk_get.md
+++ b/docs/cmd/gotk_get.md
@@ -16,7 +16,7 @@ The get sub-commands print the statuses of sources and resources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_get_helmreleases.md
+++ b/docs/cmd/gotk_get_helmreleases.md
@@ -28,7 +28,7 @@ gotk get helmreleases [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_get_kustomizations.md
+++ b/docs/cmd/gotk_get_kustomizations.md
@@ -28,7 +28,7 @@ gotk get kustomizations [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_get_sources.md
+++ b/docs/cmd/gotk_get_sources.md
@@ -16,7 +16,7 @@ The get source sub-commands print the statuses of the sources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_get_sources_git.md
+++ b/docs/cmd/gotk_get_sources_git.md
@@ -28,7 +28,7 @@ gotk get sources git [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_get_sources_helm.md
+++ b/docs/cmd/gotk_get_sources_helm.md
@@ -28,7 +28,7 @@ gotk get sources helm [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -48,7 +48,7 @@ gotk install [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile.md
+++ b/docs/cmd/gotk_reconcile.md
@@ -16,7 +16,7 @@ The reconcile sub-commands trigger a reconciliation of sources and resources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile_helmrelease.md
+++ b/docs/cmd/gotk_reconcile_helmrelease.md
@@ -33,7 +33,7 @@ gotk reconcile helmrelease [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile_kustomization.md
+++ b/docs/cmd/gotk_reconcile_kustomization.md
@@ -33,7 +33,7 @@ gotk reconcile kustomization [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile_source.md
+++ b/docs/cmd/gotk_reconcile_source.md
@@ -16,7 +16,7 @@ The reconcile source sub-commands trigger a reconciliation of sources.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile_source_git.md
+++ b/docs/cmd/gotk_reconcile_source_git.md
@@ -28,7 +28,7 @@ gotk reconcile source git [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_reconcile_source_helm.md
+++ b/docs/cmd/gotk_reconcile_source_helm.md
@@ -28,7 +28,7 @@ gotk reconcile source helm [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_resume.md
+++ b/docs/cmd/gotk_resume.md
@@ -16,7 +16,7 @@ The resume sub-commands resume a suspended resource.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_resume_helmrelease.md
+++ b/docs/cmd/gotk_resume_helmrelease.md
@@ -29,7 +29,7 @@ gotk resume helmrelease [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_resume_kustomization.md
+++ b/docs/cmd/gotk_resume_kustomization.md
@@ -29,7 +29,7 @@ gotk resume kustomization [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_suspend.md
+++ b/docs/cmd/gotk_suspend.md
@@ -16,7 +16,7 @@ The suspend sub-commands suspend the reconciliation of a resource.
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_suspend_helmrelease.md
+++ b/docs/cmd/gotk_suspend_helmrelease.md
@@ -28,7 +28,7 @@ gotk suspend helmrelease [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_suspend_kustomization.md
+++ b/docs/cmd/gotk_suspend_kustomization.md
@@ -28,7 +28,7 @@ gotk suspend kustomization [name] [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/docs/cmd/gotk_uninstall.md
+++ b/docs/cmd/gotk_uninstall.md
@@ -35,7 +35,7 @@ gotk uninstall [flags]
 
 ```
       --kubeconfig string   path to the kubeconfig file (default "~/.kube/config")
-      --namespace string    the namespace scope for this operation (default "gitops-system")
+  -n, --namespace string    the namespace scope for this operation (default "gitops-system")
       --timeout duration    timeout for this operation (default 5m0s)
       --verbose             print generated objects
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Create source: cmd/gotk_create_source.md
     - Create source git: cmd/gotk_create_source_git.md
     - Create source helm: cmd/gotk_create_source_helm.md
+    - Create tenant: cmd/gotk_create_tenant.md
     - Delete: cmd/gotk_delete.md
     - Delete kustomization: cmd/gotk_delete_kustomization.md
     - Delete helmrelease: cmd/gotk_delete_helmrelease.md


### PR DESCRIPTION
This PR adds a command for defining tenants. A tenant is composed of a namespace and a role binding that grants 
admin access to that namespace to the gotk reconciler user.

Ref: #238

Example:

```sh
$ gotk create tenant web-team --export
``` 

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
    name: web-team
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
    name: gotk-reconciler
  namespace: web-team
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: gotk:web-team:reconciler
```

cc @stealthybox I've used `cluster-admin` instead of `admin` because admin doesn't grant access to custom resources.