### PR TITLE
Add support for ARMv7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     env:
       - CGO_ENABLED=0
 archives:

--- a/cmd/gotk/install.go
+++ b/cmd/gotk/install.go
@@ -275,7 +275,7 @@ images:
 {{- if eq $arch "amd64" }}
     newName: {{$registry}}/{{$component}}
 {{- else }}
-    newName: {{$registry}}/{{$component}}-{{$arch}}
+    newName: {{$registry}}/{{$component}}-arm64
 {{- end }}
 {{- end }}
 {{- end }}

--- a/cmd/gotk/main.go
+++ b/cmd/gotk/main.go
@@ -110,7 +110,7 @@ var (
 	defaultVersion                = "latest"
 	defaultNamespace              = "gitops-system"
 	defaultNotification           = "notification-controller"
-	supportedArch                 = []string{"arm64", "amd64"}
+	supportedArch                 = []string{"amd64", "arm", "arm64"}
 	supportedDecryptionProviders  = []string{"sops"}
 	supportedHelmChartSourceKinds = []string{sourcev1.HelmRepositoryKind, sourcev1.GitRepositoryKind}
 	supportedLogLevels            = []string{"debug", "info", "error"}

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -34,7 +34,7 @@ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 ```
 
 The install script downloads the gotk binary to `/usr/local/bin`.
-Binaries for macOS and Linux AMD64/ARM64 are available for download on the 
+Binaries for macOS and Linux AMD64/ARM are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 
 To configure your shell to load gotk completions add to your Bash profile:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -23,10 +23,13 @@ With Bash:
 curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 
 # enable completions in ~/.bash_profile
-. <(gotk completion)
+. <(gotk completion bash)
 ```
 
-Binaries for macOS and Linux AMD64/ARM64 are available for download on the 
+Command-line completion for `zsh`, `fish`, and `powershell`
+are also supported with their own sub-commands.
+
+Binaries for macOS and Linux AMD64/ARM are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 
 Verify that your cluster satisfies the prerequisites with:
@@ -58,9 +61,10 @@ gotk bootstrap <GIT-PROVIDER> \
   --version=latest
 ```
 
-!!! hint "ARM64"
-    When deploying to a Kubernetes cluster with ARM 64-bit architecture,
-    you can use `--arch=arm64` to pull the linux/arm64 toolkit container images.
+!!! hint "ARM"
+    When deploying to a Kubernetes cluster with ARM architecture,
+    you can use `--arch=arm` for ARMv7 32-bit container images
+    and `--arch=arm64` for ARMv8 64-bit container images.
 
 If you wish to install a specific version, use the toolkit 
 [release tag](https://github.com/fluxcd/toolkit/releases) e.g. `--version=v0.0.14`.


### PR DESCRIPTION
This adds `--arch=arm` to install/bootstrap for cluster with ARMv7 nodes. On the next release, gotk binaries for amd64, arm64 and arm/v7 will be made available on the release page.

Fix: #246 