### PR TITLE
Add option to disable the network policy at install time

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -52,6 +52,7 @@ var (
 	bootstrapArch               string
 	bootstrapBranch             string
 	bootstrapWatchAllNamespaces bool
+	bootstrapNetworkPolicy      bool
 	bootstrapLogLevel           string
 	bootstrapManifestsPath      string
 	bootstrapRequiredComponents = []string{"source-controller", "kustomize-controller"}
@@ -80,6 +81,8 @@ func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapWatchAllNamespaces, "watch-all-namespaces", true,
 		"watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed")
+	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapNetworkPolicy, "network-policy", true,
+		"deny ingress access to the toolkit controllers from other namespaces using network policies")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapLogLevel, "log-level", "info", "set the controllers log level")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapManifestsPath, "manifests", "", "path to the manifest directory")
 	bootstrapCmd.PersistentFlags().MarkHidden("manifests")
@@ -126,7 +129,7 @@ func generateInstallManifests(targetPath, namespace, tmpDir string, localManifes
 	}
 
 	if err := genInstallManifests(bootstrapVersion, namespace, bootstrapComponents,
-		bootstrapWatchAllNamespaces, bootstrapRegistry, bootstrapImagePullSecret,
+		bootstrapWatchAllNamespaces, bootstrapNetworkPolicy, bootstrapRegistry, bootstrapImagePullSecret,
 		bootstrapArch, bootstrapLogLevel, gotkDir); err != nil {
 		return "", fmt.Errorf("generating manifests failed: %w", err)
 	}

--- a/docs/cmd/gotk_bootstrap.md
+++ b/docs/cmd/gotk_bootstrap.md
@@ -15,6 +15,7 @@ The bootstrap sub-commands bootstrap the toolkit components on the targeted Git 
   -h, --help                       help for bootstrap
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --log-level string           set the controllers log level (default "info")
+      --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)

--- a/docs/cmd/gotk_bootstrap_github.md
+++ b/docs/cmd/gotk_bootstrap_github.md
@@ -64,6 +64,7 @@ gotk bootstrap github [flags]
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --log-level string           set the controllers log level (default "info")
   -n, --namespace string           the namespace scope for this operation (default "gotk-system")
+      --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -61,6 +61,7 @@ gotk bootstrap gitlab [flags]
       --kubeconfig string          path to the kubeconfig file (default "~/.kube/config")
       --log-level string           set the controllers log level (default "info")
   -n, --namespace string           the namespace scope for this operation (default "gotk-system")
+      --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
       --timeout duration           timeout for this operation (default 5m0s)
       --verbose                    print generated objects

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -38,6 +38,7 @@ gotk install [flags]
   -h, --help                       help for install
       --image-pull-secret string   Kubernetes secret name used for pulling the toolkit images from a private registry
       --log-level string           set the controllers log level (default "info")
+      --network-policy             deny ingress access to the toolkit controllers from other namespaces using network policies (default true)
       --registry string            container registry where the toolkit images are published (default "ghcr.io/fluxcd")
   -v, --version string             toolkit version (default "latest")
       --watch-all-namespaces       watch for custom resources in all namespaces, if set to false it will only watch the namespace where the toolkit is installed (default true)


### PR DESCRIPTION
This PR adds the `--network-policy` boolean flag (defaults to `true`) to the install and bootstrap commands. This allows users to disable the network policy that denies ingress access to the toolkit controllers from other namespaces. Disabling the network policy is not advised especially when running on a multi-tenancy cluster.

Fix: #294