### PR TITLE
Update api versions in docs

### DIFF
--- a/docs/guides/helmreleases.md
+++ b/docs/guides/helmreleases.md
@@ -38,7 +38,7 @@ source-controller will fetch the Helm repository index for this
 resource on an interval and expose it as an artifact:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -82,7 +82,7 @@ There are two caveats you should be aware of:
 An example `GitRepository`:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -128,7 +128,7 @@ With the chart source created, define a new `HelmRelease` to release
 the Helm chart:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2alpha1
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/docs/guides/mozilla-sops.md
+++ b/docs/guides/mozilla-sops.md
@@ -115,7 +115,7 @@ add the GitRepository/Kustomization manifests to the fleet repository.
 Git repository manifest:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: my-secrets

--- a/docs/guides/sealed-secrets.md
+++ b/docs/guides/sealed-secrets.md
@@ -116,7 +116,7 @@ to the fleet repository.
 Helm repository manifest:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: stable
@@ -129,7 +129,7 @@ spec:
 Helm release manifest:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2alpha1
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: sealed-secrets

--- a/docs/guides/webhook-receivers.md
+++ b/docs/guides/webhook-receivers.md
@@ -58,7 +58,7 @@ watch kubectl -n gotk-system get svc/receiver
 Create a Git source pointing to a GitHub repository that you have control over:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: GitRepository
 metadata:
   name: webapp


### PR DESCRIPTION
Using gotk 0.1.3 I've had to update the api versions shown in the docs for some of the examples to get them working in my cluster. This PR should fix those, please let me know if I've missed anything. 