### PR TITLE
Display proper revision for sources

### DIFF
--- a/cmd/gotk/get_source_bucket.go
+++ b/cmd/gotk/get_source_bucket.go
@@ -72,18 +72,22 @@ func getSourceBucketCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	var rows [][]string
 	for _, source := range list.Items {
-		row := []string{}
+		var row []string
+		var revision string
+		if source.GetArtifact() != nil {
+			revision = source.GetArtifact().Revision
+		}
 		if c := meta.GetCondition(source.Status.Conditions, meta.ReadyCondition); c != nil {
 			row = []string{
 				source.GetName(),
-				source.GetArtifact().Revision,
+				revision,
 				string(c.Status),
 				c.Message,
 			}
 		} else {
 			row = []string{
 				source.GetName(),
-				source.GetArtifact().Revision,
+				revision,
 				string(corev1.ConditionFalse),
 				"waiting to be reconciled",
 			}

--- a/cmd/gotk/get_source_git.go
+++ b/cmd/gotk/get_source_git.go
@@ -72,18 +72,22 @@ func getSourceGitCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	var rows [][]string
 	for _, source := range list.Items {
-		row := []string{}
+		var row []string
+		var revision string
+		if source.GetArtifact() != nil {
+			revision = source.GetArtifact().Revision
+		}
 		if c := meta.GetCondition(source.Status.Conditions, meta.ReadyCondition); c != nil {
 			row = []string{
 				source.GetName(),
-				"unknown",
+				revision,
 				string(c.Status),
 				c.Message,
 			}
 		} else {
 			row = []string{
 				source.GetName(),
-				source.GetArtifact().Revision,
+				revision,
 				string(corev1.ConditionFalse),
 				"waiting to be reconciled",
 			}

--- a/cmd/gotk/get_source_helm.go
+++ b/cmd/gotk/get_source_helm.go
@@ -72,18 +72,22 @@ func getSourceHelmCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	var rows [][]string
 	for _, source := range list.Items {
-		row := []string{}
+		var row []string
+		var revision string
+		if source.GetArtifact() != nil {
+			revision = source.GetArtifact().Revision
+		}
 		if c := meta.GetCondition(source.Status.Conditions, meta.ReadyCondition); c != nil {
 			row = []string{
 				source.GetName(),
-				source.GetArtifact().Revision,
+				revision,
 				string(c.Status),
 				c.Message,
 			}
 		} else {
 			row = []string{
 				source.GetName(),
-				source.GetArtifact().Revision,
+				revision,
 				string(corev1.ConditionFalse),
 				"waiting to be reconciled",
 			}


### PR DESCRIPTION
Includes a change to an empty revision string if the reconciler has not
produced an artifact yet, as this will otherwise result in a nil
pointer dereference.

Follow up on #299 