### PR TITLE
docs: Install the monitoring stack with gotk

### DIFF
--- a/manifests/monitoring/grafana/dashboards/control-plane.json
+++ b/manifests/monitoring/grafana/dashboards/control-plane.json
@@ -19,7 +19,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -79,7 +79,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -143,7 +143,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -204,7 +204,7 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -269,7 +269,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -286,7 +286,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -397,7 +397,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "decimals": null,
       "description": "",
       "fieldConfig": {
@@ -504,7 +504,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -599,7 +599,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -693,7 +693,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -710,7 +710,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -807,7 +807,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "decimals": 2,
       "description": "",
       "fieldConfig": {
@@ -913,7 +913,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "decimals": 2,
       "description": "",
       "fieldConfig": {
@@ -1016,7 +1016,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1033,7 +1033,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1144,7 +1144,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "decimals": 2,
       "description": "",
       "fieldConfig": {
@@ -1250,7 +1250,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "decimals": 2,
       "description": "",
       "fieldConfig": {
@@ -1361,13 +1361,31 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,
           "text": "gotk-system",
           "value": "gotk-system"
         },
-        "datasource": "prometheus",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "workqueue_work_duration_seconds_count",
         "hide": 0,
         "includeAll": false,

--- a/manifests/monitoring/grafana/deployment.yaml
+++ b/manifests/monitoring/grafana/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: "grafana/grafana:7.1.1"
+          image: "grafana/grafana:7.2.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -33,8 +33,8 @@ spec:
               value: "true"
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Admin
-            - name: GF_DEFAULT_THEME
-              value: "Light"
+            - name: GF_USERS_DEFAULT_THEME
+              value: "light"
           volumeMounts:
             - name: grafana
               mountPath: /var/lib/grafana

--- a/manifests/monitoring/prometheus/deployment.yaml
+++ b/manifests/monitoring/prometheus/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prometheus
       containers:
           - name: prometheus
-            image: prom/prometheus:v2.20.0
+            image: prom/prometheus:v2.21.0
             imagePullPolicy: IfNotPresent
             args:
               - '--storage.tsdb.retention=2h'

--- a/manifests/policies/allow-scraping.yaml
+++ b/manifests/policies/allow-scraping.yaml
@@ -1,11 +1,14 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: deny-ingress
+  name: allow-scraping
 spec:
   policyTypes:
     - Ingress
   ingress:
-  - from:
-    - podSelector: {}
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
   podSelector: {}

--- a/manifests/policies/allow-webhooks.yaml
+++ b/manifests/policies/allow-webhooks.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhooks
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+  podSelector:
+    matchLabels:
+      app: notification-controller

--- a/manifests/policies/kustomization.yaml
+++ b/manifests/policies/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deny-ingress.yaml
+  - allow-scraping.yaml
+  - allow-webhooks.yaml


### PR DESCRIPTION
Changes:
- Use `gotk` commands to install the monitoring stack in docs 
- Update Prometheus to `2.21.0` and Grafana to `7.2.1`
- Add network policies to allow Prometheus scraping and webhooks 
