### PR TITLE
Add ARM instruction to get started guide

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -87,6 +87,11 @@ gotk bootstrap github \
   --personal
 ```
 
+!!! hint "ARM"
+    When deploying to a Kubernetes cluster with ARM architecture,
+    you can use `--arch=arm` for ARMv7 32-bit container images
+    and `--arch=arm64` for ARMv8 64-bit container images.
+
 The bootstrap command creates a repository if one doesn't exist and
 commits the toolkit components manifests to the default branch at the specified path.
 Then it configures the target cluster to synchronize with the specified path inside the repository.
@@ -261,7 +266,6 @@ gotk bootstrap github \
   --path=prod-cluster \
   --personal
 ```
-
 Pull the changes locally:
 
 ```sh


### PR DESCRIPTION
Issue : #306 

ARM instruction are now added inside the doc. Below is screenshot how it looks like based on the PR changes.

![Screenshot from 2020-10-13 13-45-23](https://user-images.githubusercontent.com/883406/95809437-7d93fb80-0d5a-11eb-9b30-c927736ef658.png)
![Screenshot from 2020-10-13 13-45-33](https://user-images.githubusercontent.com/883406/95809441-7ec52880-0d5a-11eb-9d64-9242637f3fe0.png)
