### PR TITLE
Get rid of shell-out and invoke command directly via exec

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -150,15 +150,14 @@ func generateInstallManifests(targetPath, namespace, tmpDir string, localManifes
 }
 
 func applyInstallManifests(ctx context.Context, manifestPath string, components []string) error {
-	command := fmt.Sprintf("kubectl apply -f %s", manifestPath)
-	if _, err := utils.execCommand(ctx, ModeOS, command); err != nil {
+	kubectlArgs := []string{"apply", "-f", manifestPath}
+	if _, err := utils.execKubectlCommand(ctx, ModeOS, kubectlArgs...); err != nil {
 		return fmt.Errorf("install failed")
 	}
 
 	for _, deployment := range components {
-		command = fmt.Sprintf("kubectl -n %s rollout status deployment %s --timeout=%s",
-			namespace, deployment, timeout.String())
-		if _, err := utils.execCommand(ctx, ModeOS, command); err != nil {
+		kubectlArgs = []string{"-n", namespace, "rollout", "status", "deployment", deployment, "--timeout", timeout.String()}
+		if _, err := utils.execKubectlCommand(ctx, ModeOS, kubectlArgs...); err != nil {
 			return fmt.Errorf("install failed")
 		}
 	}
@@ -239,8 +238,8 @@ func generateSyncManifests(url, branch, name, namespace, targetPath, tmpDir stri
 }
 
 func applySyncManifests(ctx context.Context, kubeClient client.Client, name, namespace, targetPath, tmpDir string) error {
-	command := fmt.Sprintf("kubectl apply -k %s", filepath.Join(tmpDir, targetPath, namespace))
-	if _, err := utils.execCommand(ctx, ModeStderrOS, command); err != nil {
+	kubectlArgs := []string{"apply", "-k", filepath.Join(tmpDir, targetPath, namespace)}
+	if _, err := utils.execKubectlCommand(ctx, ModeStderrOS, kubectlArgs...); err != nil {
 		return err
 	}
 

--- a/cmd/gotk/install.go
+++ b/cmd/gotk/install.go
@@ -158,14 +158,13 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 	if verbose {
 		applyOutput = ModeOS
 	}
-	dryRun := ""
+
+	kubectlArgs := []string{"apply", "-f", manifest}
 	if installDryRun {
-		dryRun = "--dry-run=client"
+		args = append(args, "--dry-run=client")
 		applyOutput = ModeOS
 	}
-
-	command := fmt.Sprintf("kubectl apply -f %s %s", manifest, dryRun)
-	if _, err := utils.execCommand(ctx, applyOutput, command); err != nil {
+	if _, err := utils.execKubectlCommand(ctx, applyOutput, kubectlArgs...); err != nil {
 		return fmt.Errorf("install failed")
 	}
 
@@ -178,9 +177,8 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 
 	logger.Waitingf("verifying installation")
 	for _, deployment := range installComponents {
-		command = fmt.Sprintf("kubectl -n %s rollout status deployment %s --timeout=%s",
-			namespace, deployment, timeout.String())
-		if _, err := utils.execCommand(ctx, applyOutput, command); err != nil {
+		kubectlArgs = []string{"-n", namespace, "rollout", "status", "deployment", deployment, "--timeout", timeout.String()}
+		if _, err := utils.execKubectlCommand(ctx, applyOutput, kubectlArgs...); err != nil {
 			return fmt.Errorf("install failed")
 		} else {
 			logger.Successf("%s ready", deployment)

--- a/cmd/gotk/utils.go
+++ b/cmd/gotk/utils.go
@@ -60,9 +60,10 @@ const (
 	ModeCapture  ExecMode = "capture.stderr|stdout"
 )
 
-func (*Utils) execCommand(ctx context.Context, mode ExecMode, command string) (string, error) {
+func (*Utils) execKubectlCommand(ctx context.Context, mode ExecMode, args ...string) (string, error) {
 	var stdoutBuf, stderrBuf bytes.Buffer
-	c := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+
+	c := exec.CommandContext(ctx, "kubectl", args...)
 
 	if mode == ModeStderrOS {
 		c.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)


### PR DESCRIPTION
Hello.

Please let me know if this is something you expect here.
Or would be better to switch `execCommand` to something like `execCommand(ctx context.Context, mode ExecMode, commandName string, args ...string)`?

Related to #47

