### PR TITLE
Add secret-ref flag to create source git

### DIFF
--- a/docs/cmd/gotk_create_source_bucket.md
+++ b/docs/cmd/gotk_create_source_bucket.md
@@ -45,6 +45,7 @@ gotk create source bucket [name] [flags]
       --provider sourceBucketProvider   the S3 compatible storage provider name, available options are: (generic, aws) (default generic)
       --region string                   the bucket region
       --secret-key string               the bucket secret key
+      --secret-ref string               the name of an existing secret containing credentials
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/gotk_create_source_git.md
+++ b/docs/cmd/gotk_create_source_git.md
@@ -58,6 +58,7 @@ gotk create source git [name] [flags]
       --branch string                          git branch (default "master")
   -h, --help                                   help for git
   -p, --password string                        basic authentication password
+      --secret-ref string                      the name of an existing secret containing SSH or basic credentials
       --ssh-ecdsa-curve ecdsaCurve             SSH ECDSA public key curve (p256, p384, p521) (default p384)
       --ssh-key-algorithm publicKeyAlgorithm   SSH public key algorithm (rsa, ecdsa, ed25519) (default rsa)
       --ssh-rsa-bits rsaKeyBits                SSH RSA public key bit size (multiplies of 8) (default 2048)

--- a/docs/cmd/gotk_create_source_helm.md
+++ b/docs/cmd/gotk_create_source_helm.md
@@ -38,13 +38,14 @@ gotk create source helm [name] [flags]
 ### Options
 
 ```
-      --ca-file string     TLS authentication CA file path
-      --cert-file string   TLS authentication cert file path
-  -h, --help               help for helm
-      --key-file string    TLS authentication key file path
-  -p, --password string    basic authentication password
-      --url string         Helm repository address
-  -u, --username string    basic authentication username
+      --ca-file string      TLS authentication CA file path
+      --cert-file string    TLS authentication cert file path
+  -h, --help                help for helm
+      --key-file string     TLS authentication key file path
+  -p, --password string     basic authentication password
+      --secret-ref string   the name of an existing secret containing TLS or basic auth credentials
+      --url string          Helm repository address
+  -u, --username string     basic authentication username
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## What? 
Add secret-ref flag to `create source` options

## Why?
This allows passing the name of an existing secret that already exists in the cluster (perhaps created with terraform)


## Tested?
`make test` is passing
Manually tested with `--export`