### PR TITLE
Add GitLab HTTPS auth to bootstrap options

### DIFF
--- a/cmd/gotk/bootstrap_gitlab.go
+++ b/cmd/gotk/bootstrap_gitlab.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/pkg/git"
 )
@@ -41,14 +43,17 @@ the bootstrap command will perform an upgrade if needed.`,
 	Example: `  # Create a GitLab API token and export it as an env var
   export GITLAB_TOKEN=<my-token>
 
-  # Run bootstrap for a private repo owned by a GitLab group
+  # Run bootstrap for a private repo using HTTPS token authentication 
   gotk bootstrap gitlab --owner=<group> --repository=<repo name>
+
+  # Run bootstrap for a private repo using SSH authentication
+  gotk bootstrap gitlab --owner=<group> --repository=<repo name> --ssh-hostname=gitlab.com
 
   # Run bootstrap for a repository path
   gotk bootstrap gitlab --owner=<group> --repository=<repo name> --path=dev-cluster
 
   # Run bootstrap for a public repository on a personal account
-  gotk bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal=true 
+  gotk bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal=true
 
   # Run bootstrap for a private repo hosted on a GitLab server 
   gotk bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain>
@@ -77,7 +82,7 @@ func init() {
 	bootstrapGitLabCmd.Flags().BoolVar(&glPrivate, "private", true, "is private repository")
 	bootstrapGitLabCmd.Flags().DurationVar(&glInterval, "interval", time.Minute, "sync interval")
 	bootstrapGitLabCmd.Flags().StringVar(&glHostname, "hostname", git.GitLabDefaultHostname, "GitLab hostname")
-	bootstrapGitLabCmd.Flags().StringVar(&glSSHHostname, "ssh-hostname", "", "GitLab SSH hostname, defaults to hostname if not specified")
+	bootstrapGitLabCmd.Flags().StringVar(&glSSHHostname, "ssh-hostname", "", "GitLab SSH hostname, when specified a deploy key will be added to the repository")
 	bootstrapGitLabCmd.Flags().StringVar(&glPath, "path", "", "repository path, when specified the cluster sync will be scoped to this path")
 
 	bootstrapCmd.AddCommand(bootstrapGitLabCmd)
@@ -172,34 +177,54 @@ func bootstrapGitLabCmdRun(cmd *cobra.Command, args []string) error {
 		logger.Successf("install completed")
 	}
 
-	// setup SSH deploy key
-	if shouldCreateDeployKey(ctx, kubeClient, namespace) {
-		logger.Actionf("configuring deploy key")
-		u, err := url.Parse(repository.GetSSH())
-		if err != nil {
-			return fmt.Errorf("git URL parse failed: %w", err)
-		}
+	repoURL := repository.GetURL()
 
-		key, err := generateDeployKey(ctx, kubeClient, u, namespace)
-		if err != nil {
-			return fmt.Errorf("generating deploy key failed: %w", err)
-		}
+	if glSSHHostname != "" {
+		// setup SSH deploy key
+		repoURL = repository.GetSSH()
+		if shouldCreateDeployKey(ctx, kubeClient, namespace) {
+			logger.Actionf("configuring deploy key")
+			u, err := url.Parse(repoURL)
+			if err != nil {
+				return fmt.Errorf("git URL parse failed: %w", err)
+			}
 
-		keyName := "gotk"
-		if glPath != "" {
-			keyName = fmt.Sprintf("gotk-%s", glPath)
-		}
+			key, err := generateDeployKey(ctx, kubeClient, u, namespace)
+			if err != nil {
+				return fmt.Errorf("generating deploy key failed: %w", err)
+			}
 
-		if changed, err := provider.AddDeployKey(ctx, repository, key, keyName); err != nil {
+			keyName := "gotk"
+			if glPath != "" {
+				keyName = fmt.Sprintf("gotk-%s", glPath)
+			}
+
+			if changed, err := provider.AddDeployKey(ctx, repository, key, keyName); err != nil {
+				return err
+			} else if changed {
+				logger.Successf("deploy key configured")
+			}
+		}
+	} else {
+		// setup HTTPS token auth
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespace,
+				Namespace: namespace,
+			},
+			StringData: map[string]string{
+				"username": "git",
+				"password": glToken,
+			},
+		}
+		if err := upsertSecret(ctx, kubeClient, secret); err != nil {
 			return err
-		} else if changed {
-			logger.Successf("deploy key configured")
 		}
 	}
 
 	// configure repo synchronization
 	logger.Actionf("generating sync manifests")
-	if err := generateSyncManifests(repository.GetSSH(), bootstrapBranch, namespace, namespace, glPath, tmpDir, glInterval); err != nil {
+	if err := generateSyncManifests(repoURL, bootstrapBranch, namespace, namespace, glPath, tmpDir, glInterval); err != nil {
 		return err
 	}
 

--- a/docs/cmd/gotk_bootstrap_gitlab.md
+++ b/docs/cmd/gotk_bootstrap_gitlab.md
@@ -20,14 +20,17 @@ gotk bootstrap gitlab [flags]
   # Create a GitLab API token and export it as an env var
   export GITLAB_TOKEN=<my-token>
 
-  # Run bootstrap for a private repo owned by a GitLab group
+  # Run bootstrap for a private repo using HTTPS token authentication 
   gotk bootstrap gitlab --owner=<group> --repository=<repo name>
+
+  # Run bootstrap for a private repo using SSH authentication
+  gotk bootstrap gitlab --owner=<group> --repository=<repo name> --ssh-hostname=gitlab.com
 
   # Run bootstrap for a repository path
   gotk bootstrap gitlab --owner=<group> --repository=<repo name> --path=dev-cluster
 
   # Run bootstrap for a public repository on a personal account
-  gotk bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal=true 
+  gotk bootstrap gitlab --owner=<user> --repository=<repo name> --private=false --personal=true
 
   # Run bootstrap for a private repo hosted on a GitLab server 
   gotk bootstrap gitlab --owner=<group> --repository=<repo name> --hostname=<domain>
@@ -48,7 +51,7 @@ gotk bootstrap gitlab [flags]
       --personal              is personal repository
       --private               is private repository (default true)
       --repository string     GitLab repository name
-      --ssh-hostname string   GitLab SSH hostname, defaults to hostname if not specified
+      --ssh-hostname string   GitLab SSH hostname, when specified a deploy key will be added to the repository
 ```
 
 ### Options inherited from parent commands

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -154,6 +154,22 @@ gotk bootstrap gitlab \
   --personal
 ```
 
+To run the bootstrap for a repository using deploy keys for authentication, you have to specify the SSH hostname:
+
+```sh
+gotk bootstrap gitlab \
+  --ssh-hostname=gitlab.com \
+  --owner=my-gitlab-username \
+  --repository=my-repository \
+  --branch=master \
+  --path=my-cluster
+```
+
+!!! hint "Authentication"
+    When providing the `--ssh-hostname`, a readonly deploy key will be added 
+    to your repository, otherwise your GitLab personal token will be used to
+    authenticate against the HTTPS endpoint instead of SSH.
+
 Run the bootstrap for a repository owned by a GitLab group:
 
 ```sh


### PR DESCRIPTION
This PR changes the bootstrap procedure for GitLab. It will generate a deploy key only when `--ssh-hostname` is specified, otherwise it uses the `GITLAB_TOKEN` to authenticate against Git over HTTPS instead of SSH.

Testing this PR:
```
git clone https://github.com/fluxcd/toolkit.git
cd toolkit
git checkout gitlab-https-auth

# needs Go 1.15
make build

# HTTPS Auth
./cmd/gotk bootstrap gitlab --owner=<group> --repository=<repo name> \
--hostname=gitlab.com

# SSH Auth (uses the GitLab deploy keys API)
./cmd/gotk bootstrap gitlab --owner=<group> --repository=<repo name> \
--hostname=gitlab.com \
--ssh-hostname=gitlab.com
```

Using HTTPS auth should fix: #335 and fix: https://github.com/fluxcd/source-controller/issues/120

PS. I tested this on Gitlab.com with both https and ssh.