### PR TITLE
Refactor create, reconcile and resume commands

### DIFF
--- a/cmd/gotk/bootstrap.go
+++ b/cmd/gotk/bootstrap.go
@@ -246,13 +246,15 @@ func applySyncManifests(ctx context.Context, kubeClient client.Client, name, nam
 
 	logger.Waitingf("waiting for cluster sync")
 
+	var gitRepository sourcev1.GitRepository
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isGitRepositoryReady(ctx, kubeClient, name, namespace)); err != nil {
+		isGitRepositoryReady(ctx, kubeClient, types.NamespacedName{Name: name, Namespace: namespace}, &gitRepository)); err != nil {
 		return err
 	}
 
+	var kustomization kustomizev1.Kustomization
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isKustomizationReady(ctx, kubeClient, name, namespace)); err != nil {
+		isKustomizationReady(ctx, kubeClient, types.NamespacedName{Name: name, Namespace: namespace}, &kustomization)); err != nil {
 		return err
 	}
 

--- a/cmd/gotk/reconcile_alert.go
+++ b/cmd/gotk/reconcile_alert.go
@@ -45,7 +45,7 @@ func init() {
 
 func reconcileAlertCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("alert name is required")
+		return fmt.Errorf("Alert name is required")
 	}
 	name := args[0]
 
@@ -62,7 +62,7 @@ func reconcileAlertCmdRun(cmd *cobra.Command, args []string) error {
 		Name:      name,
 	}
 
-	logger.Actionf("annotating alert %s in %s namespace", name, namespace)
+	logger.Actionf("annotating Alert %s in %s namespace", name, namespace)
 	var alert notificationv1.Alert
 	err = kubeClient.Get(ctx, namespacedName, &alert)
 	if err != nil {
@@ -79,15 +79,13 @@ func reconcileAlertCmdRun(cmd *cobra.Command, args []string) error {
 	if err := kubeClient.Update(ctx, &alert); err != nil {
 		return err
 	}
-	logger.Successf("alert annotated")
+	logger.Successf("Alert annotated")
 
 	logger.Waitingf("waiting for reconciliation")
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isAlertReady(ctx, kubeClient, name, namespace)); err != nil {
+		isAlertReady(ctx, kubeClient, namespacedName, &alert)); err != nil {
 		return err
 	}
-
-	logger.Successf("alert reconciliation completed")
-
+	logger.Successf("Alert reconciliation completed")
 	return nil
 }

--- a/cmd/gotk/reconcile_alertprovider.go
+++ b/cmd/gotk/reconcile_alertprovider.go
@@ -45,7 +45,7 @@ func init() {
 
 func reconcileAlertProviderCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("provider name is required")
+		return fmt.Errorf("Provider name is required")
 	}
 	name := args[0]
 
@@ -62,7 +62,7 @@ func reconcileAlertProviderCmdRun(cmd *cobra.Command, args []string) error {
 		Name:      name,
 	}
 
-	logger.Actionf("annotating provider %s in %s namespace", name, namespace)
+	logger.Actionf("annotating Provider %s in %s namespace", name, namespace)
 	var alertProvider notificationv1.Provider
 	err = kubeClient.Get(ctx, namespacedName, &alertProvider)
 	if err != nil {
@@ -79,15 +79,13 @@ func reconcileAlertProviderCmdRun(cmd *cobra.Command, args []string) error {
 	if err := kubeClient.Update(ctx, &alertProvider); err != nil {
 		return err
 	}
-	logger.Successf("provider annotated")
+	logger.Successf("Provider annotated")
 
 	logger.Waitingf("waiting for reconciliation")
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isAlertProviderReady(ctx, kubeClient, name, namespace)); err != nil {
+		isAlertProviderReady(ctx, kubeClient, namespacedName, &alertProvider)); err != nil {
 		return err
 	}
-
-	logger.Successf("provider reconciliation completed")
-
+	logger.Successf("Provider reconciliation completed")
 	return nil
 }

--- a/cmd/gotk/reconcile_receiver.go
+++ b/cmd/gotk/reconcile_receiver.go
@@ -62,7 +62,7 @@ func reconcileReceiverCmdRun(cmd *cobra.Command, args []string) error {
 		Name:      name,
 	}
 
-	logger.Actionf("annotating receiver %s in %s namespace", name, namespace)
+	logger.Actionf("annotating Receiver %s in %s namespace", name, namespace)
 	var receiver notificationv1.Receiver
 	err = kubeClient.Get(ctx, namespacedName, &receiver)
 	if err != nil {
@@ -79,15 +79,15 @@ func reconcileReceiverCmdRun(cmd *cobra.Command, args []string) error {
 	if err := kubeClient.Update(ctx, &receiver); err != nil {
 		return err
 	}
-	logger.Successf("receiver annotated")
+	logger.Successf("Receiver annotated")
 
-	logger.Waitingf("waiting for reconciliation")
+	logger.Waitingf("waiting for Receiver reconciliation")
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isReceiverReady(ctx, kubeClient, name, namespace)); err != nil {
+		isReceiverReady(ctx, kubeClient, namespacedName, &receiver)); err != nil {
 		return err
 	}
 
-	logger.Successf("receiver reconciliation completed")
+	logger.Successf("Receiver reconciliation completed")
 
 	return nil
 }

--- a/cmd/gotk/resume_alert.go
+++ b/cmd/gotk/resume_alert.go
@@ -78,24 +78,17 @@ func resumeAlertCmdRun(cmd *cobra.Command, args []string) error {
 
 	logger.Waitingf("waiting for Alert reconciliation")
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isAlertResumed(ctx, kubeClient, name, namespace)); err != nil {
+		isAlertResumed(ctx, kubeClient, namespacedName, &alert)); err != nil {
 		return err
 	}
-
 	logger.Successf("Alert reconciliation completed")
-
 	return nil
 }
 
-func isAlertResumed(ctx context.Context, kubeClient client.Client, name, namespace string) wait.ConditionFunc {
+func isAlertResumed(ctx context.Context, kubeClient client.Client,
+	namespacedName types.NamespacedName, alert *notificationv1.Alert) wait.ConditionFunc {
 	return func() (bool, error) {
-		var alert notificationv1.Alert
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
-		}
-
-		err := kubeClient.Get(ctx, namespacedName, &alert)
+		err := kubeClient.Get(ctx, namespacedName, alert)
 		if err != nil {
 			return false, err
 		}

--- a/cmd/gotk/resume_receiver.go
+++ b/cmd/gotk/resume_receiver.go
@@ -78,24 +78,18 @@ func resumeReceiverCmdRun(cmd *cobra.Command, args []string) error {
 
 	logger.Waitingf("waiting for Receiver reconciliation")
 	if err := wait.PollImmediate(pollInterval, timeout,
-		isReceiverResumed(ctx, kubeClient, name, namespace)); err != nil {
+		isReceiverResumed(ctx, kubeClient, namespacedName, &receiver)); err != nil {
 		return err
 	}
 
 	logger.Successf("Receiver reconciliation completed")
-
 	return nil
 }
 
-func isReceiverResumed(ctx context.Context, kubeClient client.Client, name, namespace string) wait.ConditionFunc {
+func isReceiverResumed(ctx context.Context, kubeClient client.Client,
+	namespacedName types.NamespacedName, receiver *notificationv1.Receiver) wait.ConditionFunc {
 	return func() (bool, error) {
-		var receiver notificationv1.Receiver
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
-		}
-
-		err := kubeClient.Get(ctx, namespacedName, &receiver)
+		err := kubeClient.Get(ctx, namespacedName, receiver)
 		if err != nil {
 			return false, err
 		}

--- a/docs/cmd/gotk_create_helmrelease.md
+++ b/docs/cmd/gotk_create_helmrelease.md
@@ -66,7 +66,7 @@ gotk create helmrelease [name] [flags]
       --chart-version string      Helm chart version, accepts a semver range (ignored for charts from GitRepository sources)
       --depends-on stringArray    HelmReleases that must be ready before this release can be installed, supported formats '<name>' and '<namespace>/<name>'
   -h, --help                      help for helmrelease
-      --release-name string       name used for the Helm release, defaults to a composition of '[<target-namespace>-]<hr-name>'
+      --release-name string       name used for the Helm release, defaults to a composition of '[<target-namespace>-]<HelmRelease-name>'
       --source string             source that contains the chart (<kind>/<name>)
       --target-namespace string   namespace to install this release, defaults to the HelmRelease namespace
       --values string             local path to the values.yaml file

--- a/docs/cmd/gotk_reconcile_kustomization.md
+++ b/docs/cmd/gotk_reconcile_kustomization.md
@@ -26,7 +26,7 @@ gotk reconcile kustomization [name] [flags]
 
 ```
   -h, --help          help for kustomization
-      --with-source   reconcile kustomization source
+      --with-source   reconcile Kustomization source
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
* Take ObservedGeneration into account in readiness checks where
  applicable
* Reduce amount of code (and duplicate GETs) by working with pointers
  where possible
* Improve logged messages to properly take resource names into account
  and better describe processes

First point addresses https://github.com/fluxcd/helm-controller/issues/112