### PR TITLE
Add Windows OS to CLI install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 . <(gotk completion bash)
 ```
 
-Binaries for macOS and Linux AMD64/ARM64 are available to download on the
+Binaries for macOS, Windows and Linux AMD64/ARM are available to download on the
 [release page](https://github.com/fluxcd/toolkit/releases).
 
 Verify that your cluster satisfies the prerequisites with:

--- a/docs/components/helm/controller.md
+++ b/docs/components/helm/controller.md
@@ -24,4 +24,4 @@ Features:
 Links:
 
 - Source code [fluxcd/helm-controller](https://github.com/fluxcd/helm-controller)
-- Specification [docs](https://github.com/fluxcd/helm-controller/tree/master/docs/spec)
+- Specification [docs](https://github.com/fluxcd/helm-controller/tree/main/docs/spec)

--- a/docs/components/kustomize/controller.md
+++ b/docs/components/kustomize/controller.md
@@ -20,4 +20,4 @@ Features:
 Links:
 
 - Source code [fluxcd/kustomize-controller](https://github.com/fluxcd/kustomize-controller)
-- Specification [docs](https://github.com/fluxcd/kustomize-controller/tree/master/docs/spec)
+- Specification [docs](https://github.com/fluxcd/kustomize-controller/tree/main/docs/spec)

--- a/docs/components/notification/controller.md
+++ b/docs/components/notification/controller.md
@@ -14,4 +14,4 @@ based on event severity and involved objects.
 Links:
 
 - Source code [fluxcd/notification-controller](https://github.com/fluxcd/notification-controller)
-- Specification [docs](https://github.com/fluxcd/notification-controller/tree/master/docs/spec)
+- Specification [docs](https://github.com/fluxcd/notification-controller/tree/main/docs/spec)

--- a/docs/components/source/controller.md
+++ b/docs/components/source/controller.md
@@ -21,4 +21,4 @@ Features:
 Links:
 
 - Source code [fluxcd/source-controller](https://github.com/fluxcd/source-controller)
-- Specification [docs](https://github.com/fluxcd/source-controller/tree/master/docs/spec)
+- Specification [docs](https://github.com/fluxcd/source-controller/tree/main/docs/spec)

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -34,7 +34,8 @@ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 ```
 
 The install script downloads the gotk binary to `/usr/local/bin`.
-Binaries for macOS and Linux AMD64/ARM are available for download on the 
+
+Binaries for **macOS**, **Windows** and **Linux** AMD64/ARM are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 
 To configure your shell to load gotk completions add to your Bash profile:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -29,7 +29,7 @@ curl -s https://toolkit.fluxcd.io/install.sh | sudo bash
 Command-line completion for `zsh`, `fish`, and `powershell`
 are also supported with their own sub-commands.
 
-Binaries for macOS and Linux AMD64/ARM are available for download on the 
+Binaries for macOS, Windows and Linux AMD64/ARM are available for download on the 
 [release page](https://github.com/fluxcd/toolkit/releases).
 
 Verify that your cluster satisfies the prerequisites with:


### PR DESCRIPTION
Starting with `v0.1.7`, Windows binaries are available for download from GitHub releases page.