### PR TITLE
Refactor manifest generation into a separate package

### DIFF
--- a/cmd/gotk/install.go
+++ b/cmd/gotk/install.go
@@ -42,10 +42,10 @@ If a previous version is installed, then an in-place upgrade will be performed.`
   # Dry-run install for a specific version and a series of components
   gotk install --dry-run --version=v0.0.7 --components="source-controller,kustomize-controller"
 
-  # Dry-run install with manifests preview 
+  # Dry-run install with manifests preview
   gotk install --dry-run --verbose
 
-  # Write install manifests to file 
+  # Write install manifests to file
   gotk install --export > gotk-system.yaml
 `,
 	RunE: installCmdRun,
@@ -123,24 +123,23 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		opts.BaseURL = install.MakeDefaultOptions().BaseURL
 	}
 
-	output, err := install.Generate(opts)
+	_, content, err := install.Generate(opts)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
 
 	manifest := path.Join(tmpDir, fmt.Sprintf("%s.yaml", namespace))
-	if err := ioutil.WriteFile(manifest, output, os.ModePerm); err != nil {
+	if err := ioutil.WriteFile(manifest, []byte(content), os.ModePerm); err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
 
-	yaml := string(output)
 	if verbose {
-		fmt.Print(yaml)
+		fmt.Print(content)
 	} else if installExport {
 		fmt.Println("---")
 		fmt.Println("# GitOps Toolkit revision", installVersion)
 		fmt.Println("# Components:", strings.Join(installComponents, ","))
-		fmt.Print(yaml)
+		fmt.Print(content)
 		fmt.Println("---")
 		return nil
 	}

--- a/docs/cmd/gotk_install.md
+++ b/docs/cmd/gotk_install.md
@@ -20,10 +20,10 @@ gotk install [flags]
   # Dry-run install for a specific version and a series of components
   gotk install --dry-run --version=v0.0.7 --components="source-controller,kustomize-controller"
 
-  # Dry-run install with manifests preview 
+  # Dry-run install with manifests preview
   gotk install --dry-run --verbose
 
-  # Write install manifests to file 
+  # Write install manifests to file
   gotk install --export > gotk-system.yaml
 
 ```

--- a/pkg/install/options.go
+++ b/pkg/install/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	NotificationController string
 	ManifestsFile          string
 	Timeout                time.Duration
+	TargetPath             string
 }
 
 func MakeDefaultOptions() Options {
@@ -51,6 +52,7 @@ func MakeDefaultOptions() Options {
 		NotificationController: "notification-controller",
 		ManifestsFile:          "toolkit-components.yaml",
 		Timeout:                time.Minute,
+		TargetPath:             "",
 	}
 }
 

--- a/pkg/sync/options.go
+++ b/pkg/sync/options.go
@@ -1,0 +1,23 @@
+package sync
+
+import "time"
+
+type Options struct {
+	Interval   time.Duration
+	URL        string
+	Name       string
+	Namespace  string
+	Branch     string
+	TargetPath string
+}
+
+func MakeDefaultOptions() Options {
+	return Options{
+		Interval:   1 * time.Minute,
+		URL:        "",
+		Name:       "gotk-system",
+		Namespace:  "gotk-system",
+		Branch:     "main",
+		TargetPath: "",
+	}
+}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1,0 +1,88 @@
+package sync
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+)
+
+const (
+	bootstrapSourceManifest        = "toolkit-source.yaml"
+	bootstrapKustomizationManifest = "toolkit-kustomization.yaml"
+)
+
+func Generate(options Options) ([]map[string]string, error) {
+	files := []map[string]string{}
+
+	gvk := sourcev1.GroupVersion.WithKind(sourcev1.GitRepositoryKind)
+	gitRepository := sourcev1.GitRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      options.Name,
+			Namespace: options.Namespace,
+		},
+		Spec: sourcev1.GitRepositorySpec{
+			URL: options.URL,
+			Interval: metav1.Duration{
+				Duration: options.Interval,
+			},
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: options.Branch,
+			},
+			SecretRef: &corev1.LocalObjectReference{
+				Name: options.Name,
+			},
+		},
+	}
+
+	gitData, err := yaml.Marshal(gitRepository)
+	if err != nil {
+		return nil, err
+	}
+
+	files = append(files, map[string]string{"file_path": filepath.Join(options.TargetPath, options.Namespace, bootstrapSourceManifest), "content": string(gitData)})
+
+	gvk = kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)
+	kustomization := kustomizev1.Kustomization{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      options.Name,
+			Namespace: options.Namespace,
+		},
+		Spec: kustomizev1.KustomizationSpec{
+			Interval: metav1.Duration{
+				Duration: 10 * time.Minute,
+			},
+			Path:  fmt.Sprintf("./%s", strings.TrimPrefix(options.TargetPath, "./")),
+			Prune: true,
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Kind: sourcev1.GitRepositoryKind,
+				Name: options.Name,
+			},
+			Validation: "client",
+		},
+	}
+
+	ksData, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return nil, err
+	}
+
+	files = append(files, map[string]string{"file_path": filepath.Join(options.TargetPath, options.Namespace, bootstrapKustomizationManifest), "content": string(ksData)})
+
+	return files, nil
+}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Flux authors
+Copyright 2020 The Flux CD contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,27 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package install
+package sync
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 
 func TestGenerate(t *testing.T) {
 	opts := MakeDefaultOptions()
-	_, output, err := Generate(opts)
+	output, err := Generate(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, component := range opts.Components {
-		img := fmt.Sprintf("%s/%s", opts.Registry, component)
-		if !strings.Contains(string(output), img) {
-			t.Errorf("component image '%s' not found", img)
-		}
-	}
-
-	fmt.Println(string(output))
+	fmt.Println(output)
 }


### PR DESCRIPTION
The reason the manifest generation is refactored into a separate package is to make it possible for other projects to use the code.

The change also includes changing the return parameters as the file path and the content is important for the Terraform provider rather than reading files from a temp directory.